### PR TITLE
fix: add /var/log/otelcol-sumo on darwin

### DIFF
--- a/assets/productbuild/uninstall.sh
+++ b/assets/productbuild/uninstall.sh
@@ -43,6 +43,7 @@ collector_files=(
   "/usr/local/bin/otelcol-sumo"
   "/var/lib/otelcol-sumo/file_storage"
   "/var/lib/otelcol-sumo"
+  "/var/log/otelcol-sumo"
 )
 
 # A list of files & directories to remove for hostmetrics

--- a/ci/verify_installer.sh
+++ b/ci/verify_installer.sh
@@ -52,6 +52,7 @@ expected_collector_files=(
   "usr/local/bin/otelcol-sumo"
   "var/lib/otelcol-sumo"
   "var/lib/otelcol-sumo/file_storage"
+  "var/log/otelcol-sumo"
 )
 
 # a list of files that the hostmetrics package should install

--- a/ci/verify_installer.sh
+++ b/ci/verify_installer.sh
@@ -39,6 +39,7 @@ system_files=(
   "usr/local/bin"
   "var"
   "var/lib"
+  "var/log"
 )
 
 # a list of files that the collector package should install

--- a/components/otelcol-sumo.cmake
+++ b/components/otelcol-sumo.cmake
@@ -15,6 +15,7 @@ macro(default_otc_darwin_install)
   install_otc_config_fragment_directory()
   install_otc_state_directory()
   install_otc_filestorage_state_directory()
+  install_otc_log_directory()
   install_otc_sumologic_yaml()
   install_otc_darwin_hostmetrics_yaml()
   install_otc_binary()
@@ -112,6 +113,22 @@ macro(install_otc_filestorage_state_directory)
     DIRECTORY_PERMISSIONS
       OWNER_READ OWNER_WRITE OWNER_EXECUTE
       GROUP_READ GROUP_EXECUTE
+    COMPONENT otelcol-sumo
+  )
+endmacro()
+
+# e.g. /var/log/otelcol-sumo
+macro(install_otc_log_directory)
+  require_variables(
+    "OTC_LOG_DIR"
+  )
+  install(
+    DIRECTORY
+    DESTINATION "${OTC_LOG_DIR}"
+    DIRECTORY_PERMISSIONS
+      OWNER_READ OWNER_WRITE OWNER_EXECUTE
+      GROUP_READ GROUP_EXECUTE
+      WORLD_READ WORLD_EXECUTE
     COMPONENT otelcol-sumo
   )
 endmacro()

--- a/settings/otc.cmake
+++ b/settings/otc.cmake
@@ -33,6 +33,7 @@ macro(set_otc_settings)
   set(OTC_FILESTORAGE_STATE_DIR "${OTC_STATE_DIR}/file_storage")
   set(OTC_LAUNCHD_DIR "Library/LaunchDaemons")
   set(OTC_SYSTEMD_DIR "lib/systemd/system")
+  set(OTC_LOG_DIR "var/log/otelcol-sumo")
 
   # File paths
   set(OTC_SUMOLOGIC_CONFIG_PATH "${OTC_CONFIG_DIR}/${OTC_SUMOLOGIC_CONFIG}")

--- a/templates/hooks/common/otc-darwin-functions.in
+++ b/templates/hooks/common/otc-darwin-functions.in
@@ -7,16 +7,20 @@
 otc_sumologic_config_path="${3}@OTC_SUMOLOGIC_CONFIG_PATH@"
 otc_config_fragments_dir="${3}@OTC_CONFIG_FRAGMENTS_DIR@"
 otc_launchdaemon_dir="${3}@OTC_LAUNCHD_DIR@"
+otc_log_dir="${3}@OTC_LOG_DIR@"
 
 set_file_ownership()
 {
     chown -R @SERVICE_USER@:@SERVICE_GROUP@ \
           @SERVICE_USER_HOME@ \
           "$otc_sumologic_config_path" \
-          "$otc_config_fragments_dir"
+          "$otc_config_fragments_dir" \
+          "$otc_log_dir"
 }
 
 load_otc_service()
 {
-    launchctl load "${otc_launchdaemon_dir}/com.sumologic.otelcol-sumo.plist"
+    service_plist="${otc_launchdaemon_dir}/com.sumologic.otelcol-sumo.plist"
+    launchctl unload "$service_plist"
+    launchctl load -w "$service_plist"
 }


### PR DESCRIPTION
The otelcol-sumo LaunchDaemon writes stdout & stderr to `/var/log/otelcol-sumo/otelcol-sumo.log`. This currently fails after a fresh installation as the package doesn't create the `/var/log/otelcol-sumo directory`. This change adds the directory to the otelcol-sumo component for Darwin packages.