### PR TITLE
fix: Rename SUMOLOGIC_INSTALL_TOKEN to SUMOLOGIC_INSTALLATION_TOKEN

### DIFF
--- a/assets/sumologic.yaml
+++ b/assets/sumologic.yaml
@@ -5,7 +5,7 @@ extensions:
   ## Manages registration, heartbeats and authentication to Sumo Logic
   ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALL_TOKEN}
+    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_credentials_directory: /var/lib/otelcol-sumo/credentials
 
   ## Configuration for Health Check Extension


### PR DESCRIPTION
Renames `SUMOLOGIC_INSTALL_TOKEN` to `SUMOLOGIC_INSTALLATION_TOKEN` to match https://github.com/SumoLogic/sumologic-otel-collector/blob/main/examples/sumologic.yaml.