### PR TITLE
fix: add binary target to default build target

### DIFF
--- a/packages.cmake
+++ b/packages.cmake
@@ -51,6 +51,7 @@ macro(build_cpack_config)
       message(STATUS "Creating target: ${SOURCE_OTC_BINARY}")
       file(MAKE_DIRECTORY "${SOURCE_OTC_BINARY_DIR}")
       add_custom_target("${SOURCE_OTC_BINARY}"
+        ALL
         COMMAND ${CMAKE_COMMAND} -E copy ${GH_ARTIFACT_OTC_BINARY_PATH} ${SOURCE_OTC_BINARY_PATH}
         VERBATIM
       )


### PR DESCRIPTION
Remotely triggered builds broke when https://github.com/SumoLogic/sumologic-otel-collector-packaging/pull/2 was merged. The custom target for copying the binary artifact downloaded from GitHub to the artifacts directory is not a dependency of package target (`make package`) so it never runs. This adds the custom target to all build targets and resolved the issue in my tests: https://github.com/SumoLogic/sumologic-otel-collector-packaging/actions/runs/4962831296.