### PR TITLE
feat: sign mac packages

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -24,6 +24,12 @@ on:
     secrets:
       gh_artifacts_token:
         required: true
+      apple_developer_certificate_p12_base64:
+        required: false
+      apple_developer_certificate_password:
+        required: false
+      productbuild_identity_name:
+        required: false
 
 jobs:
   build_package:
@@ -47,6 +53,15 @@ jobs:
         if: runner.os != 'Linux'
         run: mkdir build
 
+      - name: Import macOS Code-Signing Certificates
+        if: runner.os == 'macOS'
+        uses: Apple-Actions/import-codesign-certs@v2
+        with:
+          # The certificates in a PKCS12 file encoded as a base64 string
+          p12-file-base64: ${{ secrets.apple_developer_certificate_p12_base64 }}
+          # The password used to import the PKCS12 file.
+          p12-password: ${{ secrets.apple_developer_certificate_password }}
+
       - name: Build Makefile
         id: cmake-linux
         if: runner.os == 'Linux'
@@ -66,6 +81,7 @@ jobs:
           OTC_SUMO_VERSION: ${{ inputs.otc_sumo_version }}
           OTC_BUILD_NUMBER: ${{ inputs.otc_build_number }}
           TARGET: ${{ inputs.cmake_target }}
+          PRODUCTBUILD_IDENTITY_NAME: ${{ inputs.productbuild_identity_name }}
         working-directory: build
         run: cmake ../
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -115,12 +115,6 @@ jobs:
           cat /tmp/otc_sumo_version &&
           echo "version=$(cat /tmp/otc_sumo_version)" >> $GITHUB_OUTPUT
 
-      - name: Debug 1
-        run: env
-
-      - name: Debug 2
-        run: cat $GITHUB_OUTPUT
-
   # Builds a package for each cmake target in the matrix. The target must be an
   # existing file name (without extension) in the targets directory.
   build_packages:
@@ -134,6 +128,9 @@ jobs:
       otc_build_number: ${{ github.run_number }}
       cmake_target: ${{ matrix.target }}
       workflow_id: ${{ github.event.inputs.workflow_id }}
+      apple_developer_certificate_p12_base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+      apple_developer_certificate_password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      productbuild_identity_name: ${{ env.APPLE_DEVELOPER_CERTIFICATE_IDENTITY }}
       runs_on: ${{ matrix.runs_on }}
     secrets:
       gh_artifacts_token: ${{ secrets.GH_ARTIFACTS_TOKEN }}
@@ -162,9 +159,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: artifacts/
-
-      - name: Debug
-        run: env
 
       - uses: ncipollo/release-action@v1
         with:

--- a/settings/productbuild/otc.cmake
+++ b/settings/productbuild/otc.cmake
@@ -22,4 +22,8 @@ macro(set_otc_productbuild_settings)
 
   set(SOURCE_OTC_UNINSTALL_SCRIPT_PATH "${ASSETS_DIR}/productbuild/uninstall.sh")
   set(OTC_APP_SUPPORT_DIR "Library/Application Support/otelcol-sumo")
+
+  if(DEFINED ENV{PRODUCTBUILD_IDENTITY_NAME})
+    set(CPACK_PRODUCTBUILD_IDENTITY_NAME $ENV{PRODUCTBUILD_IDENTITY_NAME})
+  endif()
 endmacro()


### PR DESCRIPTION
Adds package signing for Mac packages.

The existing Apple certificate used in the sumologic-otel-collector is the wrong type for signing packages. Here's what still needs to happen before this PR will function:
1. A `Developer ID Installer` certificate needs to be generated
1. The certificate needs to be converted to base12
1. Update the GitHub Secret `APPLE_DEVELOPER_CERTIFICATE_P12_BASE64` with the base12 value
1. Update the GitHub Secret `APPLE_DEVELOPER_CERTIFICATE_PASSWORD` with the certificate password
1. Update the GitHub Variable `APPLE_DEVELOPER_CERTIFICATE_IDENTITY` with the identity of the new certificate (e.g. `Developer ID Installer: Sumo Logic, Inc. (XXXXXXXXXX)`)

To test the CMake changes I generated a certificate using my personal Apple Developer Account and then ran the following:

```sh
PRODUCTBUILD_IDENTITY_NAME="Developer ID Installer: Justin Kolberg (56F5Z4F382)" TARGET=otc_darwin_arm64_productbuild cmake ../ && make package
```

I opened the package and clicked the lock symbol in the top-right of the window and it correctly shows that it is signed:

![Screenshot 2023-05-19 at 15 39 59](https://github.com/SumoLogic/sumologic-otel-collector-packaging/assets/120659/f94a0031-c1ee-4b31-819f-027acb87dc4b)