### PR TITLE
Set OTC_ARTIFACTS_SOURCE in non-Docker builds

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -53,6 +53,10 @@ jobs:
         if: runner.os != 'Linux'
         run: mkdir build
 
+      - name: Use GitHub Artifacts for binaries
+        if: inputs.workflow_id != ''
+        run: echo "OTC_ARTIFACTS_SOURCE=github-artifacts" >> $GITHUB_ENV
+
       - name: Import macOS Code-Signing Certificates
         if: runner.os == 'macOS'
         uses: Apple-Actions/import-codesign-certs@v2


### PR DESCRIPTION
The `OTC_ARTIFACTS_SOURCE` environment variable is used in CMake to skip the downloading of artifacts from a GitHub Release in situations where those artifacts (e.g. otelcol-sumo binary) already exist. The environment variable is currently only set in the Docker `entrypoint.sh` file which is exclusively used for Linux packages. This change adds the setting of `OTC_ARTIFACTS_SOURCE` for non-Docker builds (e.g. macOS).