### PR TITLE
fix: productbuild uninstall.sh lint

### DIFF
--- a/assets/productbuild/uninstall.sh
+++ b/assets/productbuild/uninstall.sh
@@ -89,7 +89,7 @@ function stop_service() {
 
   echo "Stopping service: ${plist_file}"
 
-  launchctl unload $plist_file
+  launchctl unload "${plist_file}"
 }
 
 function uninstall_package() {


### PR DESCRIPTION
Fixes a lint error in `assets/productbuild/uninstall.sh` which was introduced in https://github.com/SumoLogic/sumologic-otel-collector-packaging/pull/10.