### PR TITLE
Clean up existing Sumo Otelcol installation

### DIFF
--- a/templates/hooks/deb/preinst.in
+++ b/templates/hooks/deb/preinst.in
@@ -2,23 +2,34 @@
 
 @common_linux_functions@
 
-function cleanup_script_install() {
-    echo "Cleaning up previous Otelcol installation ..."
+cleanup_script_install() {
+    echo "Cleaning up existing Sumo Otelcol installations (migration to native packaging) ..."
 
-    # disable systemd service
-    if [[ -f "/etc/systemd/system/otelcol-sumo.service" ]]; then
+    # stop and disable systemd service
+    if [ -f "/etc/systemd/system/otelcol-sumo.service" ]; then
+        echo "Stopping and disabling existing Sumo Otelcol service ..."
         systemctl stop otelcol-sumo || true
         systemctl disable otelcol-sumo || true
         rm -f /etc/systemd/system/otelcol-sumo.service
     fi
 
     # remove binary
-    rm -f /usr/local/bin/otelcol-sumo
+    if [ -f "/usr/local/bin/otelcol-sumo" ]; then
+        echo "Removing existing Sumo Otelcol binary ..."
+        rm -f /usr/local/bin/otelcol-sumo
+    fi
 
-    # remove configuration and data
-    rm -rf /etc/otelcol-sumo /var/lib/otelcol-sumo
+    # remove configuration
+    if [ -d "/etc/otelcol-sumo" ]; then
+        echo "Removing existing Sumo Otelcol configuration directory (/etc/otelcol-sumo) ..."
+        rm -rf /etc/otelcol-sumo
+    fi
 
-    echo "Cleanup completed"
+    # remove data
+    if [ -d "/var/lib/otelcol-sumo" ]; then
+        echo "Removing existing Sumo Otelcol data directory (/var/lib/otelcol-sumo) ..."
+        rm -rf /var/lib/otelcol-sumo
+    fi
 }
 
 case "$1" in

--- a/templates/hooks/deb/preinst.in
+++ b/templates/hooks/deb/preinst.in
@@ -2,8 +2,28 @@
 
 @common_linux_functions@
 
+function cleanup_script_install() {
+    echo "Cleaning up previous Otelcol installation ..."
+
+    # disable systemd service
+    if [[ -f "/etc/systemd/system/otelcol-sumo.service" ]]; then
+        systemctl stop otelcol-sumo || true
+        systemctl disable otelcol-sumo || true
+        rm -f /etc/systemd/system/otelcol-sumo.service
+    fi
+
+    # remove binary
+    rm -f /usr/local/bin/otelcol-sumo
+
+    # remove configuration and data
+    rm -rf /etc/otelcol-sumo /var/lib/otelcol-sumo
+
+    echo "Cleanup completed"
+}
+
 case "$1" in
     install)
+        cleanup_script_install
         create_group_if_missing
         create_user_if_missing
     ;;

--- a/templates/hooks/rpm/before-install.in
+++ b/templates/hooks/rpm/before-install.in
@@ -2,23 +2,34 @@
 
 @common_linux_functions@
 
-function cleanup_script_install() {
-    echo "Cleaning up previous Otelcol installation ..."
+cleanup_script_install() {
+    echo "Cleaning up existing Sumo Otelcol installations (migration to native packaging) ..."
 
-    # disable systemd service
-    if [[ -f "/etc/systemd/system/otelcol-sumo.service" ]]; then
+    # stop and disable systemd service
+    if [ -f "/etc/systemd/system/otelcol-sumo.service" ]; then
+        echo "Stopping and disabling existing Sumo Otelcol service ..."
         systemctl stop otelcol-sumo || true
         systemctl disable otelcol-sumo || true
         rm -f /etc/systemd/system/otelcol-sumo.service
     fi
 
     # remove binary
-    rm -f /usr/local/bin/otelcol-sumo
+    if [ -f "/usr/local/bin/otelcol-sumo" ]; then
+        echo "Removing existing Sumo Otelcol binary ..."
+        rm -f /usr/local/bin/otelcol-sumo
+    fi
 
-    # remove configuration and data
-    rm -rf /etc/otelcol-sumo /var/lib/otelcol-sumo
+    # remove configuration
+    if [ -d "/etc/otelcol-sumo" ]; then
+        echo "Removing existing Sumo Otelcol configuration directory (/etc/otelcol-sumo) ..."
+        rm -rf /etc/otelcol-sumo
+    fi
 
-    echo "Cleanup completed"
+    # remove data
+    if [ -d "/var/lib/otelcol-sumo" ]; then
+        echo "Removing existing Sumo Otelcol data directory (/var/lib/otelcol-sumo) ..."
+        rm -rf /var/lib/otelcol-sumo
+    fi
 }
 
 case "$1" in

--- a/templates/hooks/rpm/before-install.in
+++ b/templates/hooks/rpm/before-install.in
@@ -2,8 +2,28 @@
 
 @common_linux_functions@
 
+function cleanup_script_install() {
+    echo "Cleaning up previous Otelcol installation ..."
+
+    # disable systemd service
+    if [[ -f "/etc/systemd/system/otelcol-sumo.service" ]]; then
+        systemctl stop otelcol-sumo || true
+        systemctl disable otelcol-sumo || true
+        rm -f /etc/systemd/system/otelcol-sumo.service
+    fi
+
+    # remove binary
+    rm -f /usr/local/bin/otelcol-sumo
+
+    # remove configuration and data
+    rm -rf /etc/otelcol-sumo /var/lib/otelcol-sumo
+
+    echo "Cleanup completed"
+}
+
 case "$1" in
     1) # initial install
+    cleanup_script_install
     create_group_if_missing
     create_user_if_missing
     ;;


### PR DESCRIPTION
Effectively purge any existing Sumo Otelcol installation prior to installing the collector (with native packaging). These steps are based on the current installation script's uninstallation action. Doing so creates a cleaner working host environment, helping avoid file conflict scenarios etc.

Here's a screenshot of package installation right after using the S3M flow installation script to install the collector:

![Screenshot 2023-06-02 at 1 56 50 PM](https://github.com/SumoLogic/sumologic-otel-collector-packaging/assets/149630/003bd27c-9969-4ad6-b502-2f0f64661e91)
