### PR TITLE
feat: add token.env and common.yaml

### DIFF
--- a/assets/conf.d/common.yaml
+++ b/assets/conf.d/common.yaml
@@ -1,0 +1,2 @@
+extensions:
+  sumologic:

--- a/ci/verify_installer.sh
+++ b/ci/verify_installer.sh
@@ -46,6 +46,7 @@ system_files=(
 expected_collector_files=(
   "etc/otelcol-sumo"
   "etc/otelcol-sumo/conf.d"
+  "etc/otelcol-sumo/conf.d/common.yaml"
   "etc/otelcol-sumo/conf.d/examples"
   "etc/otelcol-sumo/sumologic.yaml"
   "Library/Application Support/otelcol-sumo"

--- a/components/otelcol-sumo.cmake
+++ b/components/otelcol-sumo.cmake
@@ -7,6 +7,8 @@ macro(default_otc_linux_install)
   install_otc_state_directory()
   install_otc_filestorage_state_directory()
   install_otc_sumologic_yaml()
+  install_otc_common_yaml()
+  install_otc_token_env()
   install_otc_binary()
 endmacro()
 
@@ -19,6 +21,7 @@ macro(default_otc_darwin_install)
   install_otc_filestorage_state_directory()
   install_otc_log_directory()
   install_otc_sumologic_yaml()
+  install_otc_common_yaml()
   install_otc_darwin_hostmetrics_yaml()
   install_otc_binary()
   install_otc_uninstall_script()
@@ -221,6 +224,75 @@ macro(install_otc_sumologic_yaml)
   )
 endmacro()
 
+# e.g. /etc/otelcol-sumo/env/token.env
+macro(install_otc_token_env)
+  require_variables(
+    "ASSETS_DIR"
+    "OTC_USER_ENV_DIR"
+  )
+  install(
+    FILES "${ASSETS_DIR}/env/token.env"
+    DESTINATION "${OTC_USER_ENV_DIR}"
+    PERMISSIONS
+      OWNER_READ OWNER_WRITE
+      GROUP_READ GROUP_WRITE
+    COMPONENT otelcol-sumo
+  )
+endmacro()
+
+# e.g. /etc/otelcol-sumo/conf.d/common.yaml
+macro(install_otc_common_yaml)
+  require_variables(
+    "ASSETS_DIR"
+    "OTC_CONFIG_FRAGMENTS_DIR"
+  )
+  install(
+    FILES "${ASSETS_DIR}/conf.d/common.yaml"
+    DESTINATION "${OTC_CONFIG_FRAGMENTS_DIR}"
+    PERMISSIONS
+      OWNER_READ OWNER_WRITE
+      GROUP_READ GROUP_WRITE
+    COMPONENT otelcol-sumo
+  )
+endmacro()
+
+# e.g. /etc/otelcol-sumo/conf.d/hostmetrics.yaml
+macro(install_otc_darwin_hostmetrics_yaml)
+  require_variables(
+    "ASSETS_DIR"
+    "OTC_CONFIG_FRAGMENTS_DIR"
+  )
+  install(
+    FILES "${ASSETS_DIR}/conf.d/darwin.yaml"
+    DESTINATION "${OTC_CONFIG_FRAGMENTS_DIR}"
+    RENAME "hostmetrics.yaml"
+    PERMISSIONS
+      OWNER_READ OWNER_WRITE
+      GROUP_READ
+      WORLD_READ
+    COMPONENT otelcol-sumo-hostmetrics
+  )
+endmacro()
+
+# e.g. /etc/otelcol-sumo/conf.d/hostmetrics.yaml
+macro(install_otc_linux_hostmetrics_yaml)
+  require_variables(
+    "ASSETS_DIR"
+    "OTC_CONFIG_FRAGMENTS_DIR"
+  )
+  install(
+    FILES "${ASSETS_DIR}/conf.d/linux.yaml"
+    DESTINATION "${OTC_CONFIG_FRAGMENTS_DIR}"
+    RENAME "hostmetrics.yaml"
+    PERMISSIONS
+      OWNER_READ OWNER_WRITE
+      GROUP_READ
+      WORLD_READ
+    COMPONENT otelcol-sumo-hostmetrics
+  )
+endmacro()
+
+# e.g. /etc/otelcol-sumo/sumologic.yaml
 macro(install_otc_service_systemd)
   require_variables(
     "ASSETS_DIR"
@@ -237,6 +309,7 @@ macro(install_otc_service_systemd)
   )
 endmacro()
 
+# e.g. /Library/LaunchDaemons/com.sumologic.otelcol-sumo.plist
 macro(install_otc_service_launchd)
   require_variables(
     "ASSETS_DIR"
@@ -249,41 +322,5 @@ macro(install_otc_service_launchd)
       OWNER_READ OWNER_WRITE
       GROUP_READ
     COMPONENT otelcol-sumo
-  )
-endmacro()
-
-macro(install_otc_darwin_hostmetrics_yaml)
-  require_variables(
-    "ASSETS_DIR"
-    "OTC_CONFIG_FRAGMENTS_DIR"
-    "OTC_SYSTEMD_DIR"
-  )
-  install(
-    FILES "${ASSETS_DIR}/conf.d/darwin.yaml"
-    DESTINATION "${OTC_CONFIG_FRAGMENTS_DIR}"
-    RENAME "hostmetrics.yaml"
-    PERMISSIONS
-      OWNER_READ OWNER_WRITE
-      GROUP_READ
-      WORLD_READ
-    COMPONENT otelcol-sumo-hostmetrics
-  )
-endmacro()
-
-macro(install_otc_linux_hostmetrics_yaml)
-  require_variables(
-    "ASSETS_DIR"
-    "OTC_CONFIG_FRAGMENTS_DIR"
-    "OTC_SYSTEMD_DIR"
-  )
-  install(
-    FILES "${ASSETS_DIR}/conf.d/linux.yaml"
-    DESTINATION "${OTC_CONFIG_FRAGMENTS_DIR}"
-    RENAME "hostmetrics.yaml"
-    PERMISSIONS
-      OWNER_READ OWNER_WRITE
-      GROUP_READ
-      WORLD_READ
-    COMPONENT otelcol-sumo-hostmetrics
   )
 endmacro()


### PR DESCRIPTION
Adds an empty `token.env` file on Linux and `common.yaml` with a basic structure on Darwin & Linux. This will allow ownership & permissions for those files to be controlled by packaging rather than the install script.