### PR TITLE
File ownership & permissions changes

### DIFF
--- a/assets/conf.d/common.yaml
+++ b/assets/conf.d/common.yaml
@@ -1,2 +1,3 @@
 extensions:
   sumologic:
+    collector_fields: {}

--- a/assets/deb/conffiles
+++ b/assets/deb/conffiles
@@ -1,2 +1,3 @@
 /etc/otelcol-sumo/sumologic.yaml
 /etc/otelcol-sumo/conf.d/common.yaml
+/etc/otelcol-sumo/env/token.env

--- a/components/otelcol-sumo.cmake
+++ b/components/otelcol-sumo.cmake
@@ -57,7 +57,7 @@ macro(install_otc_config_directory)
     DIRECTORY_PERMISSIONS
       OWNER_READ OWNER_WRITE OWNER_EXECUTE
       GROUP_READ GROUP_EXECUTE
-      WORLD_READ WORLD_EXECUTE
+      WORLD_EXECUTE
     COMPONENT otelcol-sumo
   )
 endmacro()
@@ -292,7 +292,7 @@ macro(install_otc_linux_hostmetrics_yaml)
   )
 endmacro()
 
-# e.g. /etc/otelcol-sumo/sumologic.yaml
+# e.g. /lib/systemd/system/sumologic.yaml
 macro(install_otc_service_systemd)
   require_variables(
     "ASSETS_DIR"

--- a/settings/rpm/common.cmake
+++ b/settings/rpm/common.cmake
@@ -10,6 +10,7 @@ macro(set_common_rpm_settings)
   set(CPACK_RPM_PACKAGE_ARCHITECTURE "${package_arch}")
   set(CPACK_RPM_PACKAGE_LICENSE "Apache-2.0")
   set(PACKAGE_FILE_EXTENSION "rpm")
+  set(CPACK_RPM_PACKAGE_RELEASE "${BUILD_NUMBER}")
 
   set(CPACK_PACKAGE_FILE_NAME "${package_name}-${PROJECT_VERSION}-${BUILD_NUMBER}.${package_arch}")
   if (DEFINED goarm)

--- a/settings/rpm/otc.cmake
+++ b/settings/rpm/otc.cmake
@@ -7,9 +7,11 @@ macro(set_otc_rpm_settings)
   render_rpm_hook_templates()
 
   set(CPACK_RPM_USER_FILELIST
-    # Mark sumologic.yaml as a config file to prevent package upgrades from
-    # replacing the file by default
+    # Mark config files to prevent package upgrades from replacing the file by
+    # default
     "%config(noreplace) /etc/otelcol-sumo/sumologic.yaml"
+    "%config(noreplace) /etc/otelcol-sumo/conf.d/common.yaml"
+    "%config(noreplace) /etc/otelcol-sumo/env/token.env"
   )
 
   # Exclude these directories from the RPM as they should already exist and

--- a/templates/hooks/common.cmake
+++ b/templates/hooks/common.cmake
@@ -11,6 +11,7 @@ function(render_common_hook_templates)
     "SERVICE_USER"
     "SERVICE_GROUP"
     "SERVICE_USER_HOME"
+    "OTC_CONFIG_DIR"
     "OTC_CONFIG_PATH"
     "OTC_USER_ENV_DIR"
     "OTC_CONFIG_FRAGMENT_DIR"

--- a/templates/hooks/common/otc-linux-functions.in
+++ b/templates/hooks/common/otc-linux-functions.in
@@ -4,7 +4,10 @@ set_file_ownership()
 {
     chown -R @SERVICE_USER@:@SERVICE_GROUP@ \
           @SERVICE_USER_HOME@ \
+          @OTC_CONFIG_DIR@ \
           @OTC_SUMOLOGIC_CONFIG_PATH@ \
+          @SERVICE_USER_HOME@ \
+          @OTC_CONFIG_DIR@ \
           @OTC_USER_ENV_DIR@ \
           @OTC_CONFIG_FRAGMENTS_DIR@
 }

--- a/templates/hooks/rpm/after-install.in
+++ b/templates/hooks/rpm/after-install.in
@@ -7,6 +7,7 @@ case "$1" in
     set_file_ownership
     ;;
     2) # upgrade
+    set_file_ownership
     ;;
 
 esac


### PR DESCRIPTION
Files with `440` permissions can be too restrictive in cases where the install script needs to be able to add/modify/remove values for tags, api_base_url, etc.

Also adds `collector_fields` with no value to `common.yaml` and sets `common.yaml` as a config file within RPMs.