### PR TITLE
chore: add common.yaml to deb conffiles

### DIFF
--- a/assets/deb/conffiles
+++ b/assets/deb/conffiles
@@ -1,1 +1,2 @@
 /etc/otelcol-sumo/sumologic.yaml
+/etc/otelcol-sumo/conf.d/common.yaml


### PR DESCRIPTION
Adds `common.yaml` to the debian `conffiles` file to specify it as a configuration file. This prevents packages from overwriting local changes to `common.yaml`.