### PR TITLE
chore: set /etc/otelcol-sumo owner to _otelcol-sumo on mac

### DIFF
--- a/templates/hooks/common/otc-darwin-functions.in
+++ b/templates/hooks/common/otc-darwin-functions.in
@@ -4,6 +4,7 @@
 # $2 - target path that the package is installing to
 # $3 - target volume that the package is installing to
 
+otc_config_dir="${3}@OTC_CONFIG_DIR@" \
 otc_sumologic_config_path="${3}@OTC_SUMOLOGIC_CONFIG_PATH@"
 otc_config_fragments_dir="${3}@OTC_CONFIG_FRAGMENTS_DIR@"
 otc_launchdaemon_dir="${3}@OTC_LAUNCHD_DIR@"
@@ -13,6 +14,7 @@ set_file_ownership()
 {
     chown -R @SERVICE_USER@:@SERVICE_GROUP@ \
           @SERVICE_USER_HOME@ \
+          "$otc_config_dir" \
           "$otc_sumologic_config_path" \
           "$otc_config_fragments_dir" \
           "$otc_log_dir"


### PR DESCRIPTION
Sets the owner of `/etc/otelcol-sumo` to the service user (`_otelcol-sumo`) on macOS. The Linux equivalent change is made in #28.