### PR TITLE
Set the right ACLs on system log files in the darwin package

### DIFF
--- a/settings/otc.cmake
+++ b/settings/otc.cmake
@@ -61,6 +61,7 @@ macro(set_otc_settings)
   # File paths
   set(SOURCE_OTC_BINARY_PATH "${SOURCE_OTC_BINARY_DIR}/${OTC_BINARY}")
   set(GH_ARTIFACT_OTC_BINARY_PATH "${GH_ARTIFACTS_DIR}/${GH_OUTPUT_OTC_BIN}")
+  set(ACL_LOG_FILE_PATHS "/var/log")
 
   ##
   # Other

--- a/templates/hooks/common/darwin-functions.in
+++ b/templates/hooks/common/darwin-functions.in
@@ -179,3 +179,13 @@ create_user_and_group_if_missing()
     # Add user to group if the user is not a member
     add_user_to_group_if_missing "$group" "$user"
 }
+
+# Allow our group to read the supplied log paths
+set_acl_on_log_paths()
+{
+    local group="$1"
+    local acl_log_file_paths="$2"
+    for log_path in ${acl_log_file_paths}; do
+        chmod -R +a "group:$group allow read,readattr,readextattr" "$log_path"
+    done
+}

--- a/templates/hooks/productbuild/preflight.in
+++ b/templates/hooks/productbuild/preflight.in
@@ -8,5 +8,6 @@
 @common_darwin_functions@
 
 create_user_and_group_if_missing "@SERVICE_USER@" "@SERVICE_GROUP@"
+set_acl_on_log_paths "@SERVICE_GROUP@" "@ACL_LOG_FILE_PATHS@"
 
 exit 0


### PR DESCRIPTION
This basically does for Darwin the same thing the install script does for Linux. Tested it locally and it worked.