### PR TITLE
deps: bump upload and download artfact actions to v4

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -164,7 +164,7 @@ jobs:
         run: make package
 
       - name: Store package as action artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.package.outputs.path }}
           path: ./build/${{ steps.package.outputs.path }}
@@ -180,7 +180,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download macOS package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build_package.outputs.package_path }}
           path: artifacts/
@@ -270,7 +270,7 @@ jobs:
           -Restore
 
       - name: Store MSI as action artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows_${{ inputs.goarch }}_msi
           path: ./msi/wix/bin/${{ inputs.package_arch }}/en-US/*.msi

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -176,7 +176,7 @@ jobs:
     if: inputs.release
     steps:
       - name: Download all packages stored as artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts/
 


### PR DESCRIPTION
These need to be upgraded together due to breaking changes.