### PR TITLE
ci: resolve msi filename conflicts

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -261,7 +261,7 @@ jobs:
         env:
           MV_FROM: ${{ env.OTC_RELEASE_ARTIFACT_NAME }}
           MV_TO: ${{ env.OTC_BUILD_INPUT_NAME }}
-        run: mv "$MV_FROM" "$MV_TO"
+        run: mv -n "$MV_FROM" "$MV_TO"
 
       - name: Rename GitHub Workflow artifact
         if: inputs.workflow_id != ''
@@ -269,7 +269,7 @@ jobs:
         env:
           MV_FROM: ${{ env.OTC_WORKFLOW_ARTIFACT_NAME }}
           MV_TO: ${{ env.OTC_BUILD_INPUT_NAME }}
-        run: mv "$MV_FROM" "$MV_TO"
+        run: mv -n "$MV_FROM" "$MV_TO"
 
       - name: Build MSI
         working-directory: ./msi/wix


### PR DESCRIPTION
When running from a triggered dev build in the collector repo, the source and destination filename can be the same. Ensure this doesn't cause an error.