### PR TITLE
ci: import macos code signing certs using custom script

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -84,14 +84,18 @@ jobs:
         if: inputs.workflow_id != ''
         run: echo "OTC_ARTIFACTS_SOURCE=github-artifacts" >> $GITHUB_ENV
 
+      # TODO: Go back to using Apple-Actions/import-codesign-certs once https://github.com/Apple-Actions/import-codesign-certs/pull/58 is merged
       - name: Import macOS Code-Signing Certificates
         if: ${{ runner.os == 'macOS' && env.MACOS_SIGNING_ENABLED == 'true' }}
-        uses: Apple-Actions/import-codesign-certs@v2
-        with:
-          # The certificates in a PKCS12 file encoded as a base64 string
-          p12-file-base64: ${{ secrets.apple_developer_certificate_p12_base64 }}
-          # The password used to import the PKCS12 file.
-          p12-password: ${{ secrets.apple_developer_certificate_password }}
+        run: |
+          export p12_filepath=$(mktemp)
+          echo '${{ secrets.apple_developer_certificate_p12_base64 }}' | base64 --decode >${p12_filepath}
+          /usr/bin/security create-keychain -p ${{ secrets.apple_developer_certificate_password }} signing_temp.keychain
+          /usr/bin/security set-keychain-settings -lut 21600 signing_temp.keychain
+          /usr/bin/security unlock-keychain -p ${{ secrets.apple_developer_certificate_password }} signing_temp.keychain
+          /usr/bin/security import ${p12_filepath} -k signing_temp.keychain -f pkcs12 -A -T /usr/bin/codesign -T /usr/bin/security -P ${{ secrets.apple_developer_certificate_password }}
+          /usr/bin/security set-key-partition-list -S apple-tool:,apple: -k ${{ secrets.apple_developer_certificate_password }} signing_temp.keychain
+          /usr/bin/security list-keychains -d user -s signing_temp.keychain login.keychain
 
       - name: Build Makefile
         id: cmake-linux


### PR DESCRIPTION
The action we're using hasn't been updated to Node 20, and GHA will stop supporting it soon.