### PR TITLE
ci: create a git ref for the annotated release tag

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -214,11 +214,12 @@ jobs:
           path: artifacts/
 
       # Create the release tag separately to add a message to it
+      # NOTE: As per the github API, we need to create the tag object first, and then the git reference
       - name: Create release tag
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.git.createTag({
+            const tagRequest = await github.rest.git.createTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag: '${{ env.RELEASE_TAG_NAME }}',
@@ -229,6 +230,12 @@ jobs:
                 name: "${{ github.actor }}",
                 email: "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com",
               },
+            })
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ env.RELEASE_TAG_NAME }}',
+              sha: tagRequest.data.sha
             })
 
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
Finally fix annotated release tags for releases. Turns out you need to create a tag object, and then a tag ref pointing to that object. This now works correctly, see: https://github.com/SumoLogic/sumologic-otel-collector-packaging/releases/tag/v0.97.0-1187.