### PR TITLE
Add --opamp-api-url flag to unix install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ UpgradeLog*.htm
 wix/packages
 msi/wix/packages
 msi/SumoLogic.wixext/packages
+install-script/test/sumologic_scripts_tests.test

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -1366,7 +1366,7 @@ function write_opamp_endpoint() {
 
     # ToDo: ensure we override only sumologic `api_base_url`
     if grep "endpoint" "${file}" > /dev/null; then
-        sed -i.bak -e "s/endpoint:.*$/endpoint: $(escape_sed "${api_url}")/" "${file}"
+        sed -i.bak -e "s/endpoint:.*$/endpoint: $(escape_sed "${opamp_endpoint}")/" "${file}"
     else
         # write endpoint on the top of sumologic: opamp: extension
         sed -i.bak -e "1,/opamp:/ s/opamp:/opamp:\\

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -705,7 +705,7 @@ function setup_config() {
         fi
 
         if [[ -n "${OPAMP_API_URL}" ]]; then
-            write_opamp_endpoint "${OPAMP_API_URL}" "${CONFIG_PATH}" "${EXT_INDENDATION}"
+            write_opamp_endpoint "${OPAMP_API_URL}" "${CONFIG_PATH}" "${EXT_INDENTATION}"
         fi
 
         if [[ -n "${FIELDS}" ]]; then

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -11,6 +11,8 @@ ARG_SHORT_HELP='h'
 ARG_LONG_HELP='help'
 ARG_SHORT_API='a'
 ARG_LONG_API='api'
+ARG_SHORT_OPAMP_API='o'
+ARG_LONG_OPAMP_API='opamp-api'
 ARG_SHORT_TAG='t'
 ARG_LONG_TAG='tag'
 ARG_SHORT_VERSION='v'
@@ -81,6 +83,7 @@ fi
 set -u
 
 API_BASE_URL=""
+OPAMP_API_URL=""
 FIELDS=""
 VERSION=""
 FIPS=false
@@ -107,6 +110,7 @@ LAUNCHD_ENV_KEY=""
 LAUNCHD_TOKEN_KEY=""
 
 USER_API_URL=""
+USER_OPAMP_API_URL=""
 USER_TOKEN=""
 USER_FIELDS=""
 
@@ -132,7 +136,7 @@ SYSTEMD_DISABLED=false
 function usage() {
   cat << EOF
 
-Usage: bash install.sh [--${ARG_LONG_TOKEN} <token>] [--${ARG_LONG_TAG} <key>=<value> [ --${ARG_LONG_TAG} ...]] [--${ARG_LONG_API} <url>] [--${ARG_LONG_VERSION} <version>] \\
+Usage: bash install.sh [--${ARG_LONG_TOKEN} <token>] [--${ARG_LONG_TAG} <key>=<value> [ --${ARG_LONG_TAG} ...]] [--${ARG_LONG_API} <url>] [--${ARG_LONG_OPAMP_API} <url>] [--${ARG_LONG_VERSION} <version>] \\
                        [--${ARG_LONG_YES}] [--${ARG_LONG_VERSION} <version>] [--${ARG_LONG_HELP}]
 
 Supported arguments:
@@ -148,7 +152,8 @@ Supported arguments:
   -${ARG_SHORT_PURGE}, --${ARG_LONG_PURGE}                           It has to be used with '--${ARG_LONG_UNINSTALL}'.
                                         It removes all Sumo Logic Distribution for OpenTelemetry Collector related configuration and data.
 
-  -${ARG_SHORT_API}, --${ARG_LONG_API} <url>                       Api URL
+  -${ARG_SHORT_API}, --${ARG_LONG_API} <url>                       API URL, forces the collector to use non-default API
+  -${ARG_SHORT_OPAMP_API}, --${ARG_LONG_OPAMP_API} <url>            OpAmp API URL, forces the collector to use non-default OpAmp API
   -${ARG_SHORT_SKIP_SYSTEMD}, --${ARG_LONG_SKIP_SYSTEMD}                    Do not install systemd unit.
   -${ARG_SHORT_SKIP_CONFIG}, --${ARG_LONG_SKIP_CONFIG}                     Do not create default configuration.
   -${ARG_SHORT_VERSION}, --${ARG_LONG_VERSION} <version>               Version of Sumo Logic Distribution for OpenTelemetry Collector to install, e.g. 0.57.2-sumo-1.
@@ -209,6 +214,9 @@ function parse_options() {
         echo "--${DEPRECATED_ARG_LONG_TOKEN}" is deprecated. Please use "--${ARG_LONG_TOKEN}" instead.
         set -- "$@" "-${ARG_SHORT_TOKEN}"
         ;;
+      "--${ARG_LONG_OPAMP_API}")
+        set -- "$@" "-${ARG_SHORT_OPAMP_API}"
+        ;;
       "--${ARG_LONG_API}")
         set -- "$@" "-${ARG_SHORT_API}"
         ;;
@@ -261,7 +269,7 @@ function parse_options() {
       "--${ARG_LONG_TIMEOUT}")
         set -- "$@" "-${ARG_SHORT_TIMEOUT}"
         ;;
-      "-${ARG_SHORT_TOKEN}"|"-${ARG_SHORT_HELP}"|"-${ARG_SHORT_API}"|"-${ARG_SHORT_TAG}"|"-${ARG_SHORT_SKIP_CONFIG}"|"-${ARG_SHORT_VERSION}"|"-${ARG_SHORT_FIPS}"|"-${ARG_SHORT_YES}"|"-${ARG_SHORT_SKIP_SYSTEMD}"|"-${ARG_SHORT_UNINSTALL}"|"-${ARG_SHORT_PURGE}"|"-${ARG_SHORT_SKIP_TOKEN}"|"-${ARG_SHORT_DOWNLOAD}"|"-${ARG_SHORT_CONFIG_BRANCH}"|"-${ARG_SHORT_BINARY_BRANCH}"|"-${ARG_SHORT_BRANCH}"|"-${ARG_SHORT_KEEP_DOWNLOADS}"|"-${ARG_SHORT_TIMEOUT}"|"-${ARG_SHORT_INSTALL_HOSTMETRICS}"|"-${ARG_SHORT_REMOTELY_MANAGED}"|"-${ARG_SHORT_EPHEMERAL}")
+      "-${ARG_SHORT_TOKEN}"|"-${ARG_SHORT_HELP}"|"-${ARG_SHORT_API}"|"-${ARG_SHORT_OPAMP_API}"|"-${ARG_SHORT_TAG}"|"-${ARG_SHORT_SKIP_CONFIG}"|"-${ARG_SHORT_VERSION}"|"-${ARG_SHORT_FIPS}"|"-${ARG_SHORT_YES}"|"-${ARG_SHORT_SKIP_SYSTEMD}"|"-${ARG_SHORT_UNINSTALL}"|"-${ARG_SHORT_PURGE}"|"-${ARG_SHORT_SKIP_TOKEN}"|"-${ARG_SHORT_DOWNLOAD}"|"-${ARG_SHORT_CONFIG_BRANCH}"|"-${ARG_SHORT_BINARY_BRANCH}"|"-${ARG_SHORT_BRANCH}"|"-${ARG_SHORT_KEEP_DOWNLOADS}"|"-${ARG_SHORT_TIMEOUT}"|"-${ARG_SHORT_INSTALL_HOSTMETRICS}"|"-${ARG_SHORT_REMOTELY_MANAGED}"|"-${ARG_SHORT_EPHEMERAL}")
         set -- "$@" "${arg}"
         ;;
       "--${ARG_LONG_INSTALL_HOSTMETRICS}")
@@ -285,7 +293,7 @@ function parse_options() {
 
   while true; do
     set +e
-    getopts "${ARG_SHORT_HELP}${ARG_SHORT_TOKEN}:${ARG_SHORT_API}:${ARG_SHORT_TAG}:${ARG_SHORT_VERSION}:${ARG_SHORT_FIPS}${ARG_SHORT_YES}${ARG_SHORT_SKIP_SYSTEMD}${ARG_SHORT_UNINSTALL}${ARG_SHORT_PURGE}${ARG_SHORT_SKIP_TOKEN}${ARG_SHORT_SKIP_CONFIG}${ARG_SHORT_DOWNLOAD}${ARG_SHORT_KEEP_DOWNLOADS}${ARG_SHORT_CONFIG_BRANCH}:${ARG_SHORT_BINARY_BRANCH}:${ARG_SHORT_BRANCH}:${ARG_SHORT_EPHEMERAL}${ARG_SHORT_REMOTELY_MANAGED}${ARG_SHORT_INSTALL_HOSTMETRICS}${ARG_SHORT_TIMEOUT}:" opt
+    getopts "${ARG_SHORT_HELP}${ARG_SHORT_TOKEN}:${ARG_SHORT_API}:${ARG_SHORT_OPAMP_API}:${ARG_SHORT_TAG}:${ARG_SHORT_VERSION}:${ARG_SHORT_FIPS}${ARG_SHORT_YES}${ARG_SHORT_SKIP_SYSTEMD}${ARG_SHORT_UNINSTALL}${ARG_SHORT_PURGE}${ARG_SHORT_SKIP_TOKEN}${ARG_SHORT_SKIP_CONFIG}${ARG_SHORT_DOWNLOAD}${ARG_SHORT_KEEP_DOWNLOADS}${ARG_SHORT_CONFIG_BRANCH}:${ARG_SHORT_BINARY_BRANCH}:${ARG_SHORT_BRANCH}:${ARG_SHORT_EPHEMERAL}${ARG_SHORT_REMOTELY_MANAGED}${ARG_SHORT_INSTALL_HOSTMETRICS}${ARG_SHORT_TIMEOUT}:" opt
     set -e
 
     # Invalid argument catched, print and exit
@@ -300,6 +308,7 @@ function parse_options() {
       "${ARG_SHORT_HELP}")          usage; exit 0 ;;
       "${ARG_SHORT_TOKEN}")         SUMOLOGIC_INSTALLATION_TOKEN="${OPTARG}" ;;
       "${ARG_SHORT_API}")           API_BASE_URL="${OPTARG}" ;;
+      "${ARG_SHORT_OPAMP_API}")     OPAMP_API_URL="${OPTARG}" ;;
       "${ARG_SHORT_SKIP_CONFIG}")   SKIP_CONFIG=true ;;
       "${ARG_SHORT_VERSION}")       VERSION="${OPTARG}" ;;
       "${ARG_SHORT_FIPS}")          FIPS=true ;;
@@ -681,7 +690,7 @@ function setup_config() {
         mkdir -p "${REMOTE_CONFIG_DIRECTORY}"
 
         write_sumologic_extension "${CONFIG_PATH}" "${INDENTATION}"
-        write_opamp_extension "${CONFIG_PATH}" "${REMOTE_CONFIG_DIRECTORY}" "${INDENTATION}" "${EXT_INDENTATION}" "${API_BASE_URL}"
+        write_opamp_extension "${CONFIG_PATH}" "${REMOTE_CONFIG_DIRECTORY}" "${INDENTATION}" "${EXT_INDENTATION}" "${OPAMP_API_URL}"
 
         if [[ -n "${SUMOLOGIC_INSTALLATION_TOKEN}" && "${SYSTEMD_DISABLED}" == "true" ]]; then
             write_installation_token "${SUMOLOGIC_INSTALLATION_TOKEN}" "${CONFIG_PATH}" "${EXT_INDENTATION}"
@@ -751,6 +760,11 @@ function setup_config() {
             write_api_url "${API_BASE_URL}" "${COMMON_CONFIG_PATH}" "${EXT_INDENTATION}"
         fi
 
+        # fill in opamp url
+        if [[ -n "${OPAMP_API_URL}" && -z "${USER_OPAMP_API_URL}" ]]; then
+            write_opamp_extension "${CONFIG_PATH}" "${REMOTE_CONFIG_DIRECTORY}" "${INDENTATION}" "${EXT_INDENTATION}" "${OPAMP_API_URL}"
+        fi
+
         if [[ -n "${FIELDS}" && -z "${USER_FIELDS}" ]]; then
             write_tags "${FIELDS}" "${COMMON_CONFIG_PATH}" "${INDENTATION}" "${EXT_INDENTATION}"
         fi
@@ -796,7 +810,7 @@ function setup_config_darwin() {
         echo -e "Creating remote configurations directory (${REMOTE_CONFIG_DIRECTORY})"
         mkdir -p "${REMOTE_CONFIG_DIRECTORY}"
 
-        write_opamp_extension "${config_path}" "${REMOTE_CONFIG_DIRECTORY}" "${INDENTATION}" "${EXT_INDENTATION}" "${API_BASE_URL}"
+        write_opamp_extension "${config_path}" "${REMOTE_CONFIG_DIRECTORY}" "${INDENTATION}" "${EXT_INDENTATION}" "${OPAMP_API_URL}"
 
         write_remote_config_launchd "${LAUNCHD_CONFIG}"
 
@@ -1380,18 +1394,11 @@ ${indentation}opamp:/" "${file}"
 
     # if a different base url is specified, configure the corresponding opamp endpoint
     if [[ -n "${api_url}" ]]; then
-        wss_url=${api_url/https:/"wss:"}
-        wss_url=${wss_url%/}
-        wss_url=${wss_url/open-events/"opamp-events"}
-        wss_url=${wss_url/open-collectors/"opamp-collectors"}
-        wss_url=${wss_url/\.net/".net/v1/opamp"}
-        wss_url=${wss_url/\.com/".com/v1/opamp"}
-
         if grep "endpoint: wss:" "${file}" > /dev/null; then
-            sed -i.bak -e "s/endpoint: wss:.*$/endpoint: $(escape_sed "${wss_url}")/" "${file}"
+            sed -i.bak -e "s/endpoint: wss:.*$/endpoint: $(escape_sed "${api_url}")/" "${file}"
         else
             sed -i.bak -e "s/opamp:/opamp:\\
-\\${ext_indentation}endpoint: $(escape_sed "${wss_url}")/" "${file}"
+\\${ext_indentation}endpoint: $(escape_sed "${api_url}")/" "${file}"
         fi
     fi
 
@@ -1712,7 +1719,7 @@ set_tmpdir
 install_missing_dependencies
 check_dependencies
 
-readonly SUMOLOGIC_INSTALLATION_TOKEN API_BASE_URL FIELDS CONTINUE FILE_STORAGE CONFIG_DIRECTORY SYSTEMD_CONFIG UNINSTALL
+readonly SUMOLOGIC_INSTALLATION_TOKEN API_BASE_URL OPAMP_API_URL FIELDS CONTINUE FILE_STORAGE CONFIG_DIRECTORY SYSTEMD_CONFIG UNINSTALL
 readonly USER_CONFIG_DIRECTORY USER_ENV_DIRECTORY CONFIG_DIRECTORY CONFIG_PATH COMMON_CONFIG_PATH
 readonly ACL_LOG_FILE_PATHS
 readonly INSTALL_HOSTMETRICS
@@ -1763,6 +1770,12 @@ if [[ -z "${DOWNLOAD_ONLY}" ]]; then
         USER_API_URL="$(get_user_api_url "${COMMON_CONFIG_PATH}")"
         if [[ -n "${USER_API_URL}" && -n "${API_BASE_URL}" && "${USER_API_URL}" != "${API_BASE_URL}" ]]; then
             echo "You are trying to install with different api base url than in your configuration file!"
+            exit 1
+        fi
+
+        USER_OPAMP_API_URL="$(get_user_opamp_api_url "${COMMON_CONFIG_PATH}")"
+        if [[ -n "${USER_OPAMP_API_URL}" && -n "${OPAMP_API_URL}" && "${USER_OPAMP_API_URL}" != "${OPAMP_API_URL}" ]]; then
+            echo "You are trying to install with different opamp endpoint than in your configuration file!"
             exit 1
         fi
 

--- a/install-script/test/check.go
+++ b/install-script/test/check.go
@@ -106,6 +106,13 @@ func checkNoBakFilesPresent(c check) {
 	}
 }
 
+func checkOpAmpEndpointSet(c check) {
+	conf, err := getConfig(configPath)
+	require.NoError(c.test, err, "error while reading configuration")
+
+	require.Equal(c.test, conf.Extensions.OpAmp.Endpoint, "wss://example.com")
+}
+
 func checkHostmetricsConfigCreated(c check) {
 	require.FileExists(c.test, hostmetricsConfigPath, "hostmetrics configuration has not been created properly")
 }

--- a/install-script/test/command_unix.go
+++ b/install-script/test/command_unix.go
@@ -32,6 +32,7 @@ type installOptions struct {
 	remotelyManaged    bool
 	ephemeral          bool
 	timeout            float64
+	opampEndpoint      string
 }
 
 func (io *installOptions) string() []string {
@@ -103,6 +104,10 @@ func (io *installOptions) string() []string {
 
 	if io.timeout != 0 {
 		opts = append(opts, "--download-timeout", fmt.Sprintf("%f", io.timeout))
+	}
+
+	if io.opampEndpoint != "" {
+		opts = append(opts, "--opamp-api", io.opampEndpoint)
 	}
 
 	return opts

--- a/install-script/test/config.go
+++ b/install-script/test/config.go
@@ -12,6 +12,7 @@ type config struct {
 
 type extensions struct {
 	Sumologic sumologicExtension `yaml:"sumologic"`
+	OpAmp     opampExtension     `yaml:"opamp"`
 }
 
 type sumologicExtension struct {
@@ -19,6 +20,10 @@ type sumologicExtension struct {
 	Tags              map[string]string `yaml:"collector_fields"`
 	APIBaseURL        string            `yaml:"api_base_url"`
 	Ephemeral         bool              `yaml:"ephemeral"`
+}
+
+type opampExtension struct {
+	Endpoint string
 }
 
 func getConfig(path string) (config, error) {

--- a/install-script/test/install_unix_test.go
+++ b/install-script/test/install_unix_test.go
@@ -180,11 +180,12 @@ func TestInstallScript(t *testing.T) {
 			},
 		},
 		{
-			name: "installation token, remotely-managed, and opamp-api-url",
+			name: "installation token, remotely-managed, and opamp-api",
 			options: installOptions{
 				skipSystemd:     true,
 				installToken:    installToken,
 				remotelyManaged: true,
+				opampEndpoint:   "wss://example.com",
 			},
 			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
 			postChecks: []checkFunc{

--- a/install-script/test/install_unix_test.go
+++ b/install-script/test/install_unix_test.go
@@ -180,6 +180,27 @@ func TestInstallScript(t *testing.T) {
 			},
 		},
 		{
+			name: "installation token, remotely-managed, and opamp-api-url",
+			options: installOptions{
+				skipSystemd:     true,
+				installToken:    installToken,
+				remotelyManaged: true,
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkRemoteConfigDirectoryCreated,
+				checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkTokenInSumoConfig,
+				checkEphemeralNotInConfig(configPath),
+				checkSystemdConfigNotCreated,
+				checkUserNotExists,
+				checkOpAmpEndpointSet,
+			},
+		},
+		{
 			name: "installation token only, binary not in PATH",
 			options: installOptions{
 				skipSystemd:  true,


### PR DESCRIPTION
This commit adds a new flag to the install script, responsible for setting the OpAmp API URL.

Previously, the OpAmp API URL was computed from the API URL. However, this did not work correctly in all scenarios.

This change is related to a pending change in the agent and may need to be held back until the agent change is committed.

See https://github.com/SumoLogic/sumologic-otel-collector/pull/1519