### PR TITLE
Use the setup-go-faster github action

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -32,9 +32,7 @@ jobs:
 
       - name: Setup go
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: 'install-script/test/go.sum'
+        uses: WillAbides/setup-go-faster@v1.14.0
 
       - name: Run install script tests
         if: steps.changed-files.outputs.any_changed == 'true'


### PR DESCRIPTION
The setup-go github action is currently broken for darwin. The setup-go-faster github action is presumably not broken, and is also faster.