### PR TITLE
Fix setup-go-faster

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           files: |
             install-script/**/*
+            .github/**
 
       - name: Setup go
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Setup go
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: WillAbides/setup-go-faster@v1.14.0
+        with:
+          go-version: stable
 
       - name: Run install script tests
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Setup go
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: WillAbides/setup-go-faster@v1.14.0
+        uses: WillAbides/setup-go-faster@v1
         with:
           go-version: stable
 


### PR DESCRIPTION
It seems setup-go-faster requires the go-version input. The previous PR did not fail, even though setup-go-faster was not able to run. (Based on another PR failing, see https://github.com/SumoLogic/sumologic-otel-collector-packaging/actions/runs/8885086917/job/24395622976)

It turns out that the test was not run, because the tests are only run if the install script changes.

I've modified this, so that the test is also run when the .github directory changes.