### PR TITLE
fix(install): Suppress error when getting installed package version

### DIFF
--- a/install-script/install.ps1
+++ b/install-script/install.ps1
@@ -201,7 +201,7 @@ function Get-InstalledApplicationVersion {
 }
 
 function Get-InstalledPackageVersion {
-    $package = Get-Package -name "OpenTelemetry Collector"
+    $package = Get-Package -name "OpenTelemetry Collector" -EA Ignore
 
     if ($package -eq $null) {
         return


### PR DESCRIPTION
When the script verifies if there's already an installed version of the OpenTelemetry Collector it uses the Get-Pacakge cmdlet. However when the package is not installed it prints an error in red in the terminal but continues the installation process. This PR suppresses that error message and continues the installation.