### PR TITLE
ci: sync sumologic.yaml & sumologic-windows.yaml to otelcol repo

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,5 @@
+SumoLogic/sumologic-otel-collector:
+  - source: assets/sumologic.yaml
+    dest: assets/sumologic.yaml
+  - source: assets/sumologic-windows.yaml
+    dest: assets/sumologic-windows.yaml

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,17 @@
+name: File Sync
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  file_sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetching Local Repository
+        uses: actions/checkout@master
+      - name: Sync Files
+        uses: BetaHuhn/repo-file-sync-action@v1.21.0
+        with:
+          GH_PAT: ${{ secrets.FILE_SYNC_GH_TOKEN }}

--- a/assets/sumologic-windows.yaml
+++ b/assets/sumologic-windows.yaml
@@ -3,7 +3,7 @@
 extensions:
   ## Configuration for Sumo Logic Extension
   ## Manages registration, heartbeats and authentication to Sumo Logic
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sumologicextension
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_credentials_directory: ${PROGRAMDATA}\Sumo Logic\OpenTelemetry Collector\data\credentials
@@ -37,7 +37,7 @@ receivers:
 exporters:
   ## Configuration for Sumo Logic Exporter
   ## This exporter supports sending logs, metrics and traces data to Sumo Logic.
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.102.0/exporter/sumologicexporter
   sumologic:
     sending_queue:
       enabled: true
@@ -46,7 +46,6 @@ exporters:
       max_elapsed_time: 0
 
 processors:
-
   ## Configuration for Memory Limiter Processor
   ## The memory_limiter processor is used to prevent out of memory situations on the collector.
   ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
@@ -83,7 +82,7 @@ processors:
   resourcedetection/system:
     detectors: ["system"]
     system:
-      hostname_sources: ["dns","os"]
+      hostname_sources: ["dns", "os"]
 
 service:
   extensions:

--- a/assets/sumologic.yaml
+++ b/assets/sumologic.yaml
@@ -3,7 +3,7 @@
 extensions:
   ## Configuration for Sumo Logic Extension
   ## Manages registration, heartbeats and authentication to Sumo Logic
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sumologicextension
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_credentials_directory: /var/lib/otelcol-sumo/credentials
@@ -12,6 +12,7 @@ extensions:
   ## Health Check extension enables an HTTP url that can be probed to check the status of the OpenTelemetry Collector
   ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
   health_check:
+    endpoint: localhost:13133
 
   ## Configuration for File Storage Extension
   ## The File Storage extension can persist state to the local file system
@@ -22,6 +23,13 @@ extensions:
       on_rebound: true
     directory: /var/lib/otelcol-sumo/file_storage
 
+  ## Configuration for OpAMP Extension
+  ## The OpAMP extension remotely manages collector configuration.
+  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/opampextension
+  opamp:
+    remote_configuration_directory: /etc/otelcol-sumo/opamp.d
+    endpoint: wss://opamp-events.sumologic.com/v1/opamp
+
 receivers:
   ## Configuration for OTLP Receiver
   ## Receives data via gRPC or HTTP using OTLP format.
@@ -29,14 +37,14 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: localhost:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: localhost:4318
 
 exporters:
   ## Configuration for Sumo Logic Exporter
   ## This exporter supports sending logs, metrics and traces data to Sumo Logic.
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.102.0/exporter/sumologicexporter
   sumologic:
     sending_queue:
       enabled: true
@@ -45,7 +53,6 @@ exporters:
       max_elapsed_time: 0
 
 processors:
-
   ## Configuration for Memory Limiter Processor
   ## The memory_limiter processor is used to prevent out of memory situations on the collector.
   ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
@@ -80,15 +87,18 @@ processors:
   ## OpenTelemetry resource semantic conventions, and append or override the resource value in telemetry data with this information.
   ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
   resourcedetection/system:
-    detectors: ["system"]
+    detectors: ["system", "ec2", "gcp", "azure"]
     system:
-      hostname_sources: ["dns","os"]
+      hostname_sources: ["dns", "os"]
 
 service:
   extensions:
     - sumologic
     - health_check
     - file_storage
+  telemetry:
+    metrics:
+      address: localhost:8888
   pipelines:
     metrics/default:
       receivers:


### PR DESCRIPTION
Enables synchronization of sumologic.yaml & sumologic-windows.yaml from this repository to the https://github.com/sumologic/sumologic-otel-collector repository. This will enable us to make config changes in one repository while ensuring that the files in both repository stay in sync.