### PR TITLE
Revert "Merge pull request #64 from SumoLogic/222461-installation-logs"

### DIFF
--- a/install-script/install.ps1
+++ b/install-script/install.ps1
@@ -30,14 +30,6 @@ param (
     # The API URL used to communicate with the SumoLogic backend
     [string] $Api,
 
-    # DisableInstallationTelemetry is used to disable reporting the installation
-    # to Sumologic.
-    [bool] $DisableInstallationTelemetry,
-
-    # InstallationLogfileEndpoint is used to configure the endpoint where
-    # installation logs will be sent.
-    [string] $InstallationLogfileEndpoint,
-
     # The OpAmp Endpoint used to communicate with the OpAmp backend
     [string] $OpAmpApi
 )
@@ -407,48 +399,19 @@ function Get-BinaryFromUri {
     Write-Host "Downloaded ${Path}"
 }
 
-function Send-Installation-Logs {
-    param (
-        [Parameter(Mandatory, Position=0)]
-        [HttpClient] $HttpClient,
-
-        [Parameter(Mandatory, Position=1)]
-        [string] $Endpoint,
-
-        [Parameter(Mandatory, Position=2)]
-        [string] $Path
-    )
-
-    $Content = Get-Content -Path $Path
-    $StringContent = [System.Net.Http.StringContent]::new($Content)
-
-    $response = $HttpClient.PostAsync($Endpoint, $StringContent).GetAwaiter().GetResult()
-    if (!($response.IsSuccessStatusCode)) {
-        $statusCode = [int]$response.StatusCode
-        $reasonPhrase = $response.StatusCode.ToString()
-        $errMsg = "${statusCode} ${reasonPhrase}"
-
-        if ($response.Content -ne $null) {
-            $content = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-            $errMsg += ": ${content}"
-        }
-
-        Write-Error $errMsg -ErrorAction Stop
-    }
-}
-
 ##
 # Main code
 ##
 
 try {
-    $InstallationLogFile = New-TemporaryFile
-
-    if ($InstallationLogFileEndpoint -eq "") {
-        $InstallationLogFileEndpoint = "https://open-events.sumologic.net/api/v1/collector/installation/logs"
+    if ($InstallationToken -eq $null -or $InstallationToken -eq "") {
+        Write-Error "Installation token has not been provided. Please set the SUMOLOGIC_INSTALLATION_TOKEN environment variable." -ErrorAction Stop
     }
 
-    Start-Transcript $InstallationLogFile | Out-Null
+    $osName = Get-OSName
+    $archName = Get-ArchName
+    Write-Host "Detected OS type:`t${osName}"
+    Write-Host "Detected architecture:`t${archName}"
 
     $handler = New-Object HttpClientHandler
     $handler.AllowAutoRedirect = $true
@@ -459,15 +422,6 @@ try {
 
     # set http client timeout to 30 seconds
     $httpClient.Timeout = New-Object System.TimeSpan(0, 0, 30)
-
-    if ($InstallationToken -eq $null -or $InstallationToken -eq "") {
-        Write-Error "Installation token has not been provided. Please set the SUMOLOGIC_INSTALLATION_TOKEN environment variable." -ErrorAction Stop
-    }
-
-    $osName = Get-OSName
-    $archName = Get-ArchName
-    Write-Host "Detected OS type:`t${osName}"
-    Write-Host "Detected architecture:`t${archName}"
 
     if ($Fips -eq $true) {
         if ($osName -ne "Win32NT" -or $archName -ne "x64") {
@@ -579,12 +533,4 @@ try {
     msiexec.exe /i "$msiPath" /passive $msiProperties
 } catch [HttpRequestException] {
     Write-Error $_.Exception.InnerException.Message
-} finally {
-    Stop-Transcript | Out-Null
-
-    if ($DisableInstallationTelemetry -eq $false) {
-        Send-Installation-Logs -Endpoint $InstallationLogFileEndpoint -Path $InstallationLogFile -HttpClient $httpClient
-    }
-
-    Remove-Item $InstallationLogFile
 }

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -52,10 +52,6 @@ ARG_SHORT_EPHEMERAL='E'
 ARG_LONG_EPHEMERAL='ephemeral'
 ARG_SHORT_TIMEOUT='m'
 ARG_LONG_TIMEOUT='download-timeout'
-ARG_SHORT_DISABLE_INSTALLATION_TELEMETRY='S'
-ARG_LONG_DISABLE_INSTALLATION_TELEMETRY='disable-installation-telemetry'
-ARG_SHORT_INSTALLATION_LOGFILE_ENDPOINT='l'
-ARG_LONG_INSTALLATION_LOGFILE_ENDPOINT='installation-logfile-endpoint'
 
 PACKAGE_GITHUB_ORG="SumoLogic"
 PACKAGE_GITHUB_REPO="sumologic-otel-collector-packaging"
@@ -71,8 +67,6 @@ readonly ARG_SHORT_INSTALL_HOSTMETRICS ARG_LONG_INSTALL_HOSTMETRICS
 readonly ARG_SHORT_REMOTELY_MANAGED ARG_LONG_REMOTELY_MANAGED
 readonly ARG_SHORT_EPHEMERAL ARG_LONG_EPHEMERAL
 readonly ARG_SHORT_TIMEOUT ARG_LONG_TIMEOUT
-readonly ARG_SHORT_DISABLE_INSTALLATION_TELEMETRY ARG_LONG_DISABLE_INSTALLATION_TELEMETRY
-readonly ARG_SHORT_INSTALLATION_LOGFILE_ENDPOINT ARG_LONG_INSTALLATION_LOGFILE_ENDPOINT
 readonly DEPRECATED_ARG_LONG_TOKEN DEPRECATED_ENV_TOKEN DEPRECATED_ARG_LONG_SKIP_TOKEN
 readonly PACKAGE_GITHUB_ORG PACKAGE_GITHUB_REPO
 
@@ -137,10 +131,6 @@ CURL_MAX_TIME=1800
 # set by check_dependencies therefore cannot be set by set_defaults
 SYSTEMD_DISABLED=false
 
-DISABLE_INSTALLATION_TELEMETRY=false
-INSTALLATION_LOGFILE="${TMPDIR:=/tmp}/sumologic-otel-collector_installation.log"
-INSTALLATION_LOGFILE_ENDPOINT='https://open-events.sumologic.net/api/v1/collector/installation/logs'
-
 ############################ Functions
 
 function usage() {
@@ -174,7 +164,6 @@ Supported arguments:
   -${ARG_SHORT_EPHEMERAL}, --${ARG_LONG_EPHEMERAL}                       Delete the collector from Sumo Logic after 12 hours of inactivity.
   -${ARG_SHORT_TIMEOUT}, --${ARG_LONG_TIMEOUT} <timeout>      Timeout in seconds after which download will fail. Default is ${CURL_MAX_TIME}.
   -${ARG_SHORT_YES}, --${ARG_LONG_YES}                             Disable confirmation asks.
-  -${ARG_SHORT_DISABLE_INSTALLATION_TELEMETRY}, --${ARG_LONG_DISABLE_INSTALLATION_TELEMETRY}  Do not report installation logs to Sumologic.
 
   -${ARG_SHORT_HELP}, --${ARG_LONG_HELP}                            Prints this help and usage.
 
@@ -182,18 +171,6 @@ Supported env variables:
   ${ENV_TOKEN}=<token>       Installation token.'
 EOF
 }
-
-# shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
-# ShellCheck may incorrectly believe that code is unreachable if it's invoked in
-# a trap, like the reporter function.
-function reporter {
-    if ! $DISABLE_INSTALLATION_TELEMETRY; then
-        echo "SUMOLOGIC_INSTALLATION_TOKEN=${SUMOLOGIC_INSTALLATION_TOKEN}" >> "$INSTALLATION_LOGFILE"
-        curl --silent --location -X POST --data-binary @"${INSTALLATION_LOGFILE}" "${INSTALLATION_LOGFILE_ENDPOINT}"
-        rm -f "${INSTALLATION_LOGFILE}"
-    fi
-}
-trap reporter EXIT
 
 function set_defaults() {
     HOME_DIRECTORY="/var/lib/otelcol-sumo"
@@ -292,7 +269,7 @@ function parse_options() {
       "--${ARG_LONG_TIMEOUT}")
         set -- "$@" "-${ARG_SHORT_TIMEOUT}"
         ;;
-      "-${ARG_SHORT_TOKEN}"|"-${ARG_SHORT_HELP}"|"-${ARG_SHORT_API}"|"-${ARG_SHORT_OPAMP_API}"|"-${ARG_SHORT_TAG}"|"-${ARG_SHORT_SKIP_CONFIG}"|"-${ARG_SHORT_VERSION}"|"-${ARG_SHORT_FIPS}"|"-${ARG_SHORT_YES}"|"-${ARG_SHORT_SKIP_SYSTEMD}"|"-${ARG_SHORT_UNINSTALL}"|"-${ARG_SHORT_PURGE}"|"-${ARG_SHORT_SKIP_TOKEN}"|"-${ARG_SHORT_DOWNLOAD}"|"-${ARG_SHORT_CONFIG_BRANCH}"|"-${ARG_SHORT_BINARY_BRANCH}"|"-${ARG_SHORT_BRANCH}"|"-${ARG_SHORT_KEEP_DOWNLOADS}"|"-${ARG_SHORT_TIMEOUT}"|"-${ARG_SHORT_INSTALL_HOSTMETRICS}"|"-${ARG_SHORT_REMOTELY_MANAGED}"|"-${ARG_SHORT_EPHEMERAL}"|"-${ARG_SHORT_DISABLE_INSTALLATION_TELEMETRY}"|"-${ARG_SHORT_INSTALLATION_LOGFILE_ENDPOINT}")
+      "-${ARG_SHORT_TOKEN}"|"-${ARG_SHORT_HELP}"|"-${ARG_SHORT_API}"|"-${ARG_SHORT_OPAMP_API}"|"-${ARG_SHORT_TAG}"|"-${ARG_SHORT_SKIP_CONFIG}"|"-${ARG_SHORT_VERSION}"|"-${ARG_SHORT_FIPS}"|"-${ARG_SHORT_YES}"|"-${ARG_SHORT_SKIP_SYSTEMD}"|"-${ARG_SHORT_UNINSTALL}"|"-${ARG_SHORT_PURGE}"|"-${ARG_SHORT_SKIP_TOKEN}"|"-${ARG_SHORT_DOWNLOAD}"|"-${ARG_SHORT_CONFIG_BRANCH}"|"-${ARG_SHORT_BINARY_BRANCH}"|"-${ARG_SHORT_BRANCH}"|"-${ARG_SHORT_KEEP_DOWNLOADS}"|"-${ARG_SHORT_TIMEOUT}"|"-${ARG_SHORT_INSTALL_HOSTMETRICS}"|"-${ARG_SHORT_REMOTELY_MANAGED}"|"-${ARG_SHORT_EPHEMERAL}")
         set -- "$@" "${arg}"
         ;;
       "--${ARG_LONG_INSTALL_HOSTMETRICS}")
@@ -303,12 +280,6 @@ function parse_options() {
         ;;
       "--${ARG_LONG_EPHEMERAL}")
         set -- "$@" "-${ARG_SHORT_EPHEMERAL}"
-        ;;
-      "--${ARG_LONG_DISABLE_INSTALLATION_TELEMETRY}")
-        set -- "$@" "-${ARG_SHORT_DISABLE_INSTALLATION_TELEMETRY}"
-        ;;
-      "--${ARG_LONG_INSTALLATION_LOGFILE_ENDPOINT}")
-        set -- "$@" "-${ARG_SHORT_INSTALLATION_LOGFILE_ENDPOINT}"
         ;;
       -*)
         echo "Unknown option ${arg}"; usage; exit 1 ;;
@@ -322,7 +293,7 @@ function parse_options() {
 
   while true; do
     set +e
-    getopts "${ARG_SHORT_HELP}${ARG_SHORT_TOKEN}:${ARG_SHORT_API}:${ARG_SHORT_OPAMP_API}:${ARG_SHORT_TAG}:${ARG_SHORT_VERSION}:${ARG_SHORT_FIPS}${ARG_SHORT_YES}${ARG_SHORT_SKIP_SYSTEMD}${ARG_SHORT_UNINSTALL}${ARG_SHORT_PURGE}${ARG_SHORT_SKIP_TOKEN}${ARG_SHORT_SKIP_CONFIG}${ARG_SHORT_DOWNLOAD}${ARG_SHORT_KEEP_DOWNLOADS}${ARG_SHORT_CONFIG_BRANCH}:${ARG_SHORT_BINARY_BRANCH}:${ARG_SHORT_BRANCH}:${ARG_SHORT_EPHEMERAL}${ARG_SHORT_REMOTELY_MANAGED}${ARG_SHORT_INSTALL_HOSTMETRICS}${ARG_SHORT_TIMEOUT}:${ARG_SHORT_DISABLE_INSTALLATION_TELEMETRY}${ARG_SHORT_INSTALLATION_LOGFILE_ENDPOINT}:" opt
+    getopts "${ARG_SHORT_HELP}${ARG_SHORT_TOKEN}:${ARG_SHORT_API}:${ARG_SHORT_OPAMP_API}:${ARG_SHORT_TAG}:${ARG_SHORT_VERSION}:${ARG_SHORT_FIPS}${ARG_SHORT_YES}${ARG_SHORT_SKIP_SYSTEMD}${ARG_SHORT_UNINSTALL}${ARG_SHORT_PURGE}${ARG_SHORT_SKIP_TOKEN}${ARG_SHORT_SKIP_CONFIG}${ARG_SHORT_DOWNLOAD}${ARG_SHORT_KEEP_DOWNLOADS}${ARG_SHORT_CONFIG_BRANCH}:${ARG_SHORT_BINARY_BRANCH}:${ARG_SHORT_BRANCH}:${ARG_SHORT_EPHEMERAL}${ARG_SHORT_REMOTELY_MANAGED}${ARG_SHORT_INSTALL_HOSTMETRICS}${ARG_SHORT_TIMEOUT}:" opt
     set -e
 
     # Invalid argument catched, print and exit
@@ -334,7 +305,7 @@ function parse_options() {
 
     # Validate opt and set arguments
     case "$opt" in
-      "${ARG_SHORT_HELP}")          usage; DISABLE_INSTALLATION_TELEMETRY=true exit 0 ;;
+      "${ARG_SHORT_HELP}")          usage; exit 0 ;;
       "${ARG_SHORT_TOKEN}")         SUMOLOGIC_INSTALLATION_TOKEN="${OPTARG}" ;;
       "${ARG_SHORT_API}")           API_BASE_URL="${OPTARG}" ;;
       "${ARG_SHORT_OPAMP_API}")     OPAMP_API_URL="${OPTARG}" ;;
@@ -361,8 +332,6 @@ function parse_options() {
       "${ARG_SHORT_EPHEMERAL}") EPHEMERAL=true ;;
       "${ARG_SHORT_KEEP_DOWNLOADS}") KEEP_DOWNLOADS=true ;;
       "${ARG_SHORT_TIMEOUT}") CURL_MAX_TIME="${OPTARG}" ;;
-      "${ARG_SHORT_DISABLE_INSTALLATION_TELEMETRY}") DISABLE_INSTALLATION_TELEMETRY=true ;;
-      "${ARG_SHORT_INSTALLATION_LOGFILE_ENDPOINT}")  INSTALLATION_LOGFILE_ENDPOINT="${OPTARG}" ;;
       "${ARG_SHORT_TAG}")
         if [[ "${OPTARG}" != ?*"="* ]]; then
             echo "Invalid tag: '${OPTARG}'. Should be in 'key=value' format"
@@ -1776,9 +1745,6 @@ function plutil_replace_key() {
 }
 
 ############################ Main code
-
-# Redirect a copy of stdout and stderr into $INSTALLATION_LOGFILE
-exec > >(tee "${INSTALLATION_LOGFILE}") 2>&1
 
 OS_TYPE="$(get_os_type)"
 ARCH_TYPE="$(get_arch_type)"

--- a/install-script/test/command_unix.go
+++ b/install-script/test/command_unix.go
@@ -14,27 +14,25 @@ import (
 )
 
 type installOptions struct {
-	installToken                 string
-	autoconfirm                  bool
-	skipSystemd                  bool
-	tags                         map[string]string
-	skipConfig                   bool
-	skipInstallToken             bool
-	fips                         bool
-	envs                         map[string]string
-	uninstall                    bool
-	purge                        bool
-	apiBaseURL                   string
-	configBranch                 string
-	downloadOnly                 bool
-	dontKeepDownloads            bool
-	installHostmetrics           bool
-	remotelyManaged              bool
-	ephemeral                    bool
-	timeout                      float64
-	opampEndpoint                string
-	disableInstallationTelemetry bool
-	installationLogfileEndpoint  string
+	installToken       string
+	autoconfirm        bool
+	skipSystemd        bool
+	tags               map[string]string
+	skipConfig         bool
+	skipInstallToken   bool
+	fips               bool
+	envs               map[string]string
+	uninstall          bool
+	purge              bool
+	apiBaseURL         string
+	configBranch       string
+	downloadOnly       bool
+	dontKeepDownloads  bool
+	installHostmetrics bool
+	remotelyManaged    bool
+	ephemeral          bool
+	timeout            float64
+	opampEndpoint      string
 }
 
 func (io *installOptions) string() []string {
@@ -106,16 +104,6 @@ func (io *installOptions) string() []string {
 
 	if io.timeout != 0 {
 		opts = append(opts, "--download-timeout", fmt.Sprintf("%f", io.timeout))
-	}
-
-	if io.disableInstallationTelemetry {
-		opts = append(opts, "--disable-installation-telemetry")
-	}
-
-	if io.installationLogfileEndpoint == "" {
-		opts = append(opts, "--installation-logfile-endpoint", StagingInstallationLogfileEndpoint)
-	} else {
-		opts = append(opts, "--installation-logfile-endpoint", io.installationLogfileEndpoint)
 	}
 
 	if io.opampEndpoint != "" {

--- a/install-script/test/command_windows.go
+++ b/install-script/test/command_windows.go
@@ -12,16 +12,14 @@ import (
 )
 
 type installOptions struct {
-	installToken                 string
-	tags                         map[string]string
-	fips                         bool
-	envs                         map[string]string
-	apiBaseURL                   string
-	installHostmetrics           bool
-	remotelyManaged              bool
-	ephemeral                    bool
-	disableInstallationTelemetry bool
-	installationLogfileEndpoint  string
+	installToken       string
+	tags               map[string]string
+	fips               bool
+	envs               map[string]string
+	apiBaseURL         string
+	installHostmetrics bool
+	remotelyManaged    bool
+	ephemeral          bool
 }
 
 func (io *installOptions) string() []string {
@@ -52,16 +50,6 @@ func (io *installOptions) string() []string {
 
 	if io.apiBaseURL != "" {
 		opts = append(opts, "-Api", io.apiBaseURL)
-	}
-
-	if io.disableInstallationTelemetry {
-		opts = append(opts, "-DisableInstallationTelemetry")
-	}
-
-	if io.installationLogfileEndpoint == "" {
-		opts = append(opts, "-InstallationLogfileEndpoint", StagingInstallationLogfileEndpoint)
-	} else {
-		opts = append(opts, "-InstallationLogfileEndpoint", io.installationLogfileEndpoint)
 	}
 
 	return opts

--- a/install-script/test/common_unix.go
+++ b/install-script/test/common_unix.go
@@ -23,10 +23,9 @@ func cleanCache(t *testing.T) {
 
 func runTest(t *testing.T, spec *testSpec) {
 	ch := check{
-		test:                     t,
-		installationLogsEndpoint: new(mockInstallationLogsEndpoint),
-		installOptions:           spec.options,
-		expectedInstallCode:      spec.installCode,
+		test:                t,
+		installOptions:      spec.options,
+		expectedInstallCode: spec.installCode,
 	}
 
 	t.Log("Running conditional checks")

--- a/install-script/test/common_windows.go
+++ b/install-script/test/common_windows.go
@@ -19,10 +19,9 @@ var commonPostChecks = []checkFunc{checkNoBakFilesPresent}
 
 func runTest(t *testing.T, spec *testSpec) {
 	ch := check{
-		test:                     t,
-		installationLogsEndpoint: new(mockInstallationLogsEndpoint),
-		installOptions:           spec.options,
-		expectedInstallCode:      spec.installCode,
+		test:                t,
+		installOptions:      spec.options,
+		expectedInstallCode: spec.installCode,
 	}
 
 	t.Log("Running conditional checks")

--- a/install-script/test/consts_common.go
+++ b/install-script/test/consts_common.go
@@ -12,8 +12,6 @@ const (
 	GithubOrg           = "SumoLogic"
 	GithubAppRepository = "sumologic-otel-collector"
 	GithubApiBaseUrl    = "https://api.github.com"
-
-	StagingInstallationLogfileEndpoint string = "https://stag-open-events.sumologic.net/api/v1/collector/installation/logs"
 )
 
 var (

--- a/install-script/test/install_unix_test.go
+++ b/install-script/test/install_unix_test.go
@@ -623,26 +623,6 @@ func TestInstallScript(t *testing.T) {
 			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
 			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkUserConfigNotCreated, checkSystemdConfigNotCreated},
 		},
-		{
-			name: "installation telemetry is uploaded",
-			options: installOptions{
-				disableInstallationTelemetry: false,
-				installationLogfileEndpoint:  "http://localhost:4444/",
-			},
-			preActions:  []checkFunc{preActionStartInstallationLogsMockReceiver},
-			postChecks:  []checkFunc{checkInstallationLogsReceived},
-			installCode: 1,
-		},
-		{
-			name: "installation telemetry can be disabled",
-			options: installOptions{
-				disableInstallationTelemetry: true,
-				installationLogfileEndpoint:  "http://localhost:4444/",
-			},
-			preActions:  []checkFunc{preActionStartInstallationLogsMockReceiver},
-			postChecks:  []checkFunc{checkInstallationLogsNotReceived},
-			installCode: 1,
-		},
 	} {
 		t.Run(spec.name, func(t *testing.T) {
 			runTest(t, &spec)

--- a/install-script/test/install_windows_test.go
+++ b/install-script/test/install_windows_test.go
@@ -146,26 +146,6 @@ func TestInstallScript(t *testing.T) {
 				checkTags,
 			},
 		},
-		{
-			name: "installation telemetry is uploaded",
-			options: installOptions{
-				disableInstallationTelemetry: false,
-				installationLogfileEndpoint:  "http://localhost:4444/",
-			},
-			preActions: []checkFunc{preActionStartInstallationLogsMockReceiver},
-			postChecks: []checkFunc{checkInstallationLogsReceived},
-			installCode: 1,
-		},
-		{
-			name: "installation telemetry can be disabled",
-			options: installOptions{
-				disableInstallationTelemetry: true,
-				installationLogfileEndpoint:  "http://localhost:4444/",
-			},
-			preActions: []checkFunc{preActionStartInstallationLogsMockReceiver},
-			postChecks: []checkFunc{checkInstallationLogsNotReceived},
-			installCode: 1,
-		},
 	} {
 		t.Run(spec.name, func(t *testing.T) {
 			runTest(t, &spec)


### PR DESCRIPTION
This reverts commit 74ff6d891871e3a803a249c466ad6a7887382aa7, reversing changes made to 413816625d3b77aa12d5cf9ab98ac75f2c893fd5.

Users are getting confused by the errors shown by installation telemetry in the Windows installation script. This commit reverts the work done to add installation telemetry until we can determine how to make this less confusing. Tested on my local Windows VM by ensuring that the S3M flow still works to add a collector.