### PR TITLE
Add wrapper script for otelcol-sumo

### DIFF
--- a/assets/otelcol-sumo.sh
+++ b/assets/otelcol-sumo.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -f /etc/otelcol-sumo/sumologic-remote.yaml ]; then
+    exec /usr/local/bin/otelcol-sumo --remote-config opamp:/etc/otelcol-sumo/sumologic-remote.yaml
+else
+    exec /usr/local/bin/otelcol-sumo --config /etc/otelcol-sumo/sumologic.yaml --config "glob:/etc/otelcol-sumo/conf.d/*.yaml"
+fi


### PR DESCRIPTION
This commit adds a script that calls `exec otelcol-sumo` with either the --config or --remote-config flags, based on the presence of /etc/otelcol-sumo/sumologic-remote.yaml. Using exec replaces the shell with otelcol-sumo, so it doesn't appear in the process list as the shell script. This allows us to correctly invoke otelcol-sumo from systemd and launchd.