### PR TITLE
ci: build from GitHub Action artifacts by default

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -18,6 +18,10 @@ on:
       workflow_id:
         required: false
         type: string
+      use_release_artifacts:
+        required: false
+        type: boolean
+        default: false
       runs_on:
         required: true
         type: string
@@ -72,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Workflow URL for sumologic-otel-collector
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         run: |
           org="SumoLogic"
           repo="sumologic-otel-collector"
@@ -94,7 +98,7 @@ jobs:
         run: mkdir build
 
       - name: Use GitHub Artifacts for binaries
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         run: echo "OTC_ARTIFACTS_SOURCE=github-artifacts" >> $GITHUB_ENV
 
       # TODO: Go back to using Apple-Actions/import-codesign-certs once https://github.com/Apple-Actions/import-codesign-certs/pull/58 is merged
@@ -146,7 +150,7 @@ jobs:
 
       - name: Set simple otc-bin outputs
         id: otc-bin
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         env:
           OTC_BIN: >-
             ${{
@@ -162,7 +166,7 @@ jobs:
       # otc_version and otc_sumo_version.
       - name: Download artifacts from sumologic-otel-collector
         uses: dawidd6/action-download-artifact@v3.1.4
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         with:
           github_token: ${{ secrets.gh_artifacts_token }}
           repo: SumoLogic/sumologic-otel-collector
@@ -221,7 +225,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Workflow URL for sumologic-otel-collector
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         run: |
           org="SumoLogic"
           repo="sumologic-otel-collector"
@@ -235,7 +239,7 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       - name: Use GitHub Artifacts for binaries
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         run: echo "OTC_ARTIFACTS_SOURCE=github-artifacts" >> $GITHUB_ENV
 
       - name: Determine artifact names
@@ -250,7 +254,7 @@ jobs:
       # otc_version and otc_sumo_version.
       - name: Download artifact from workflow
         uses: dawidd6/action-download-artifact@v3.1.4
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         with:
           github_token: ${{ secrets.gh_artifacts_token }}
           repo: SumoLogic/sumologic-otel-collector
@@ -265,7 +269,7 @@ jobs:
       # GitHub Release.
       - name: Download artifact from GitHub Release
         uses: robinraju/release-downloader@v1.10
-        if: inputs.workflow_id == ''
+        if: ${{ inputs.use_release_artifacts && inputs.workflow_id == '' }}
         with:
           repository: SumoLogic/sumologic-otel-collector
           tag: v${{ inputs.otc_version }}-sumo-${{ inputs.otc_sumo_version }}
@@ -273,7 +277,7 @@ jobs:
           out-file-path: build/artifacts
 
       - name: Rename GitHub Release artifact
-        if: inputs.workflow_id == ''
+        if: ${{ inputs.use_release_artifacts && inputs.workflow_id == '' }}
         working-directory: ./build/artifacts
         env:
           MV_FROM: ${{ env.OTC_RELEASE_ARTIFACT_NAME }}
@@ -281,7 +285,7 @@ jobs:
         run: mv -n "$MV_FROM" "$MV_TO"
 
       - name: Rename GitHub Workflow artifact
-        if: inputs.workflow_id != ''
+        if: ${{ !inputs.use_release_artifacts && inputs.workflow_id != '' }}
         working-directory: ./build/artifacts
         env:
           MV_FROM: ${{ env.OTC_WORKFLOW_ARTIFACT_NAME }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -5,19 +5,31 @@
 name: 'Build packages'
 
 # Sets the name of the CI run based on whether the run was triggered by a push
-# or remotely with or without workflow_run_id set. The name used for push events
-# is the full commit message as I have not been able to find a way to only show
-# the commit title (first 72 characters of commit message) - Justin K.
+# or remotely with or without workflow_run_id or use_release_artifacts  set. The
+# name used for push events is the full commit message as I have not been able
+# to find a way to only show the commit title (first 72 characters of commit
+# message) - Justin K.
 run-name: >
   ${{
-  (inputs.workflow_id != '' &&   
+  (inputs.use_release_artifacts &&
+  inputs.otc_version != '' &&
+  inputs.otc_sumo_version != '') &&
+  format('Build for GitHub Release: {0}-sumo-{1}, Version: {0}-sumo-{1}', inputs.otc_version, inputs.otc_sumo_version)
+  ||
+  (inputs.use_release_artifacts &&
+  (inputs.otc_version == '' ||
+  inputs.otc_sumo_version == '')) &&
+  'Build for GitHub Release: latest'
+  ||
+  (inputs.workflow_id != '' &&
   inputs.otc_version != '' &&
   inputs.otc_sumo_version != '') &&
   format('Build for Remote Workflow: {0}, Version: {1}-sumo-{2}', inputs.workflow_id, inputs.otc_version, inputs.otc_sumo_version)
   ||
-  (inputs.otc_version != '' &&
+  (inputs.workflow_id == '' &&
+  inputs.otc_version != '' &&
   inputs.otc_sumo_version != '') &&
-  format('Build for GitHub Release: {0}-sumo-{1}, Version: {0}-sumo-{1}', inputs.otc_version, inputs.otc_sumo_version)
+  format('Build for Remote Workflow: latest-main, Version: {0}-sumo-{1}', inputs.otc_version, inputs.otc_sumo_version)
   ||
   inputs.workflow_id != '' &&
   format('Build for Remote Workflow: {0}, Version: unknown', inputs.workflow_id)
@@ -55,8 +67,46 @@ on:
         type: boolean
         required: false
         default: false
+      use_release_artifacts:
+        description: |
+          Fetch artifacts from a GitHub Release instead of the artifacts from a
+          GitHub CI run. Both otc_version and otc_sumo_version are required if
+          this is set to true.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
+  determine_workflow:
+    runs-on: ubuntu-latest
+    name: Determine workflow_id
+    outputs:
+      workflow_id: ${{ steps.workflow.outputs.id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Determine the latest successful run of the "Dev builds" workflow for
+      # the "main" branch. This is skipped if inputs.workflow_id is set.
+      - name: Determine latest successful workflow run
+        id: latest-workflow
+        if: inputs.workflow_id == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          R="SumoLogic/sumologic-otel-collector"
+          WFN="Dev builds"
+          W=$(gh run list -R "$R" -w "$WFN" -s success -b main --json databaseId -q '.[0].databaseId')
+          echo "id=$W" >> "$GITHUB_OUTPUT"
+
+      - name: Set output workflow
+        id: workflow
+        run: |
+            echo "id=${{ inputs.workflow_id || steps.latest-workflow.outputs.id }}" >> $GITHUB_OUTPUT
+
+      - name: Output Remote Workflow URL
+        run: echo ::notice title=Remote Workflow URL::https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/${{ steps.workflow.outputs.id }}
+
   # Determines the latest version which will be used to fetch artifacts from a
   # GitHub Release and as the version of the packages being built. This is
   # skipped if the otc_version and otc_sumo_version inputs have been set.
@@ -70,10 +120,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Output Remote Workflow URL
-        if: inputs.workflow_id != ''
-        run: echo ::notice title=Remote Workflow URL::https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/${{ inputs.workflow_id }}
-
+      # Determine the latest release version if either otc_version or
+      # otc_sumo_version are empty.
       - name: Determine latest release version
         id: release
         if: >
@@ -114,7 +162,7 @@ jobs:
         run: |
             echo "otc_version=${{ inputs.otc_version || steps.version-core.outputs.version }}" >> $GITHUB_OUTPUT
             echo "otc_sumo_version=${{ inputs.otc_sumo_version || steps.sumo-version.outputs.version }}" >> $GITHUB_OUTPUT
-      
+
       - name: Output App Version
         run: echo ::notice title=App Version::${{ steps.versions.outputs.otc_version }}-sumo-${{ steps.versions.outputs.otc_sumo_version }}
 
@@ -125,13 +173,15 @@ jobs:
     name: ${{ matrix.target }}
     uses: ./.github/workflows/_reusable_build_package.yml
     needs:
+      - determine_workflow
       - determine_version
     with:
       otc_version: ${{ needs.determine_version.outputs.otc_version }}
       otc_sumo_version: ${{ needs.determine_version.outputs.otc_sumo_version }}
       otc_build_number: ${{ github.run_number }}
       cmake_target: ${{ matrix.target }}
-      workflow_id: ${{ inputs.workflow_id }}
+      workflow_id: ${{ needs.determine_workflow.outputs.workflow_id }}
+      use_release_artifacts: ${{ inputs.use_release_artifacts || false }}
       runs_on: ${{ matrix.runs_on }}
       goarch: ${{ matrix.goarch }}
       package_arch: ${{ matrix.package_arch }}
@@ -267,4 +317,3 @@ jobs:
             This release packages [${{ env.OTC_APP_VERSION }}](https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/${{ env.OTC_APP_VERSION }}).
 
             The changelog below is for the package itself, rather than the Sumo Logic Distribution for OpenTelemetry Collector.
-

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
+        fail-fast: false
         include:
           - arch_os: linux_amd64
             runs_on: ubuntu-20.04
@@ -20,6 +21,9 @@ jobs:
             runs_on: macos-latest
           - arch_os: windows_amd64
             runs_on: windows-2022
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_CI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -31,10 +35,6 @@ jobs:
             install-script/**/*
             .github/**
 
-      - name: Set up environment variables
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CI_TOKEN }}
-
       - name: Setup go
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: WillAbides/setup-go-faster@v1
@@ -44,4 +44,4 @@ jobs:
       - name: Run install script tests
         if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: install-script/test
-        run: make test --token $GITHUB_TOKEN
+        run: make test

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -12,8 +12,8 @@ jobs:
     name: Test Install Script
     runs-on: ${{ matrix.runs_on }}
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         include:
           - arch_os: linux_amd64
             runs_on: ubuntu-20.04

--- a/install-script/test/Makefile
+++ b/install-script/test/Makefile
@@ -3,7 +3,7 @@ ifeq ($(OS),Windows_NT)
 endif
 
 ifneq ($(OS),windows)
-	GOTESTPREFIX ?= sudo env PATH="${PATH}"
+	GOTESTPREFIX ?= sudo env PATH="${PATH}" GH_CI_TOKEN="${GITHUB_TOKEN}"
 endif
 
 LINT=golangci-lint


### PR DESCRIPTION
We currently pull artifacts from GitHub Releases by default when building in this repository. Successful runs for the `Dev builds` workflow in the https://github.com/sumologic/sumologic-otel-collector repository will trigger package builds here that will use artifacts from Github Actions.

The default poses a problem where the only way to test some changes in this repository is to wait for a new release in the https://github.com/sumologic/sumologic-otel-collector repository.

This change updates the CI code to pull artifacts from GitHub CI by default which will make packaging changes more safe and allow us to iterate more quickly.

Once this is merged I will have to update the CI code in https://github.com/sumologic/sumologic-otel-collector to set `use_release_artifacts: true` when triggering package builds for tags.