### PR TITLE
feat: add fips targets for linux/amd64 & linux/arm64

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -226,6 +226,19 @@ jobs:
             goarch: amd64
             package_arch: x64
             build_tool: wix
+          # fips targets
+          - target: otc_fips_linux_amd64_deb
+            runs_on: ubuntu-latest
+            build_tool: cmake
+          - target: otc_fips_linux_amd64_rpm
+            runs_on: ubuntu-latest
+            build_tool: cmake
+          - target: otc_fips_linux_arm64_deb
+            runs_on: ubuntu-latest
+            build_tool: cmake
+          - target: otc_fips_linux_arm64_rpm
+            runs_on: ubuntu-latest
+            build_tool: cmake
           - target: otc_fips_windows_amd64_wix
             runs_on: windows-2019
             goarch: amd64

--- a/packages.cmake
+++ b/packages.cmake
@@ -132,11 +132,6 @@ macro(build_cpack_config)
     create_packagecloud_publish_target(${_pc_user} ${_pc_repo} ${_pc_distro} ${_package_output})
   endforeach()
 
-  # set(_pc_repo "stable")
-  # foreach(_pc_distro ${packagecloud_distros})
-  #   create_packagecloud_publish_target(${_pc_user} ${_pc_repo} ${_pc_distro} ${_package_output})
-  # endforeach()
-
   # Add a publish-package target to publish the package built above
   get_property(_all_publish_targets GLOBAL PROPERTY _all_publish_targets)
   add_custom_target(publish-package

--- a/settings.cmake
+++ b/settings.cmake
@@ -9,3 +9,7 @@ include("${SETTINGS_DIR}/otc.cmake")
 include("${SETTINGS_DIR}/deb/otc.cmake")
 include("${SETTINGS_DIR}/productbuild/otc.cmake")
 include("${SETTINGS_DIR}/rpm/otc.cmake")
+
+# Include OTC FIPS package settings
+include("${SETTINGS_DIR}/deb/otc_fips.cmake")
+include("${SETTINGS_DIR}/rpm/otc_fips.cmake")

--- a/settings/deb/otc.cmake
+++ b/settings/deb/otc.cmake
@@ -21,4 +21,6 @@ macro(set_otc_deb_settings)
     "${DEB_HOOK_TEMPLATES_OUTPUT_DIR}/prerm"
     "${DEB_HOOK_TEMPLATES_OUTPUT_DIR}/postrm"
   )
+
+  set(CPACK_DEBIAN_PACKAGE_CONFLICTS "otelcol-sumo-fips")
 endmacro()

--- a/settings/deb/otc_fips.cmake
+++ b/settings/deb/otc_fips.cmake
@@ -1,0 +1,5 @@
+macro(set_otc_fips_deb_settings)
+  set_otc_deb_settings()
+
+  set(CPACK_DEBIAN_PACKAGE_CONFLICTS "otelcol-sumo")
+endmacro()

--- a/settings/otc.cmake
+++ b/settings/otc.cmake
@@ -92,7 +92,7 @@ macro(set_otc_settings)
   render_common_hook_templates()
 
   # CPack configuration
-  set(CPACK_PACKAGE_NAME "otelcol-sumo")
+  set(CPACK_PACKAGE_NAME "${package_name}")
   set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${package_arch}")
   set(CPACK_RESOURCE_FILE_LICENSE "${ASSETS_DIR}/LICENSE")
   set(CPACK_PACKAGE_DESCRIPTION_FILE "${ASSETS_DIR}/description")

--- a/settings/rpm/otc.cmake
+++ b/settings/rpm/otc.cmake
@@ -30,4 +30,6 @@ macro(set_otc_rpm_settings)
   set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${RPM_HOOK_TEMPLATES_OUTPUT_DIR}/after-install")
   set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${RPM_HOOK_TEMPLATES_OUTPUT_DIR}/before-remove")
   set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${RPM_HOOK_TEMPLATES_OUTPUT_DIR}/after-remove")
+
+  set(CPACK_RPM_PACKAGE_CONFLICTS "otelcol-sumo-fips")
 endmacro()

--- a/settings/rpm/otc_fips.cmake
+++ b/settings/rpm/otc_fips.cmake
@@ -1,0 +1,5 @@
+macro(set_otc_fips_rpm_settings)
+  set_otc_rpm_settings()
+
+  set(CPACK_RPM_PACKAGE_CONFLICTS "otelcol-sumo")
+endmacro()

--- a/targets/otc_fips_linux_amd64_deb.cmake
+++ b/targets/otc_fips_linux_amd64_deb.cmake
@@ -5,10 +5,25 @@ set(goos "linux")
 set(goarch "amd64")
 set(fips 1)
 
+# Supported Debian versions
+debian_jessie()
+debian_stretch()
+debian_buster()
+debian_bullseye()
+debian_bookworm()
+
+# Supported Ubuntu versions
+ubuntu_trusty()
+ubuntu_xenial()
+ubuntu_bionic()
+ubuntu_focal()
+ubuntu_jammy()
+ubuntu_noble()
+
 set_common_settings()
 set_otc_settings()
 set_common_deb_settings()
-set_otc_deb_settings()
+set_otc_fips_deb_settings()
 
 default_otc_linux_install()
 install_otc_service_systemd()

--- a/targets/otc_fips_linux_amd64_deb.cmake
+++ b/targets/otc_fips_linux_amd64_deb.cmake
@@ -1,0 +1,16 @@
+set(package_name "otelcol-sumo-fips")
+set(package_os "linux")
+set(package_arch "amd64")
+set(goos "linux")
+set(goarch "amd64")
+set(fips 1)
+
+set_common_settings()
+set_otc_settings()
+set_common_deb_settings()
+set_otc_deb_settings()
+
+default_otc_linux_install()
+install_otc_service_systemd()
+
+build_deb_cpack_config()

--- a/targets/otc_fips_linux_amd64_rpm.cmake
+++ b/targets/otc_fips_linux_amd64_rpm.cmake
@@ -1,0 +1,16 @@
+set(package_name "otelcol-sumo-fips")
+set(package_os "linux")
+set(package_arch "x86_64")
+set(goos "linux")
+set(goarch "amd64")
+set(fips 1)
+
+set_common_settings()
+set_otc_settings()
+set_common_rpm_settings()
+set_otc_rpm_settings()
+
+default_otc_linux_install()
+install_otc_service_systemd()
+
+build_rpm_cpack_config()

--- a/targets/otc_fips_linux_amd64_rpm.cmake
+++ b/targets/otc_fips_linux_amd64_rpm.cmake
@@ -5,10 +5,40 @@ set(goos "linux")
 set(goarch "amd64")
 set(fips 1)
 
+# Supported Amazon Linux versions
+amazon_2()
+amazon_2023()
+
+# Supported Enterprise Linux versions
+el_7()
+el_8()
+el_9()
+
+# Supported Fedora versions
+fedora_39()
+fedora_40()
+
+# Supported openSUSE versions
+opensuse_15_5()
+opensuse_15_6()
+
+# Supported Oracle Linux versions
+ol_7()
+ol_8()
+ol_9()
+
+# Supported SUSE Linux Enterprise Server versions
+sles_12_5()
+sles_15_2()
+sles_15_3()
+sles_15_4()
+sles_15_5()
+sles_15_6()
+
 set_common_settings()
 set_otc_settings()
 set_common_rpm_settings()
-set_otc_rpm_settings()
+set_otc_fips_rpm_settings()
 
 default_otc_linux_install()
 install_otc_service_systemd()

--- a/targets/otc_fips_linux_arm64_deb.cmake
+++ b/targets/otc_fips_linux_arm64_deb.cmake
@@ -5,10 +5,29 @@ set(goos "linux")
 set(goarch "arm64")
 set(fips 1)
 
+# Supported Debian versions
+debian_jessie()
+debian_stretch()
+debian_buster()
+debian_bullseye()
+debian_bookworm()
+
+# Supported Ubuntu versions
+ubuntu_trusty()
+ubuntu_xenial()
+ubuntu_bionic()
+ubuntu_focal()
+ubuntu_jammy()
+ubuntu_noble()
+
+# Supported Raspbian versions
+raspbian_bullseye()
+raspbian_bookworm()
+
 set_common_settings()
 set_otc_settings()
 set_common_deb_settings()
-set_otc_deb_settings()
+set_otc_fips_deb_settings()
 
 default_otc_linux_install()
 install_otc_service_systemd()

--- a/targets/otc_fips_linux_arm64_deb.cmake
+++ b/targets/otc_fips_linux_arm64_deb.cmake
@@ -1,0 +1,16 @@
+set(package_name "otelcol-sumo-fips")
+set(package_os "linux")
+set(package_arch "arm64")
+set(goos "linux")
+set(goarch "arm64")
+set(fips 1)
+
+set_common_settings()
+set_otc_settings()
+set_common_deb_settings()
+set_otc_deb_settings()
+
+default_otc_linux_install()
+install_otc_service_systemd()
+
+build_deb_cpack_config()

--- a/targets/otc_fips_linux_arm64_rpm.cmake
+++ b/targets/otc_fips_linux_arm64_rpm.cmake
@@ -5,10 +5,40 @@ set(goos "linux")
 set(goarch "arm64")
 set(fips 1)
 
+# Supported Amazon Linux versions
+amazon_2()
+amazon_2023()
+
+# Supported Enterprise Linux versions
+el_7()
+el_8()
+el_9()
+
+# Supported Fedora versions
+fedora_39()
+fedora_40()
+
+# Supported openSUSE versions
+opensuse_15_5()
+opensuse_15_6()
+
+# Supported Oracle Linux versions
+ol_7()
+ol_8()
+ol_9()
+
+# Supported SUSE Linux Enterprise Server versions
+sles_12_5()
+sles_15_2()
+sles_15_3()
+sles_15_4()
+sles_15_5()
+sles_15_6()
+
 set_common_settings()
 set_otc_settings()
 set_common_rpm_settings()
-set_otc_rpm_settings()
+set_otc_fips_rpm_settings()
 
 default_otc_linux_install()
 install_otc_service_systemd()

--- a/targets/otc_fips_linux_arm64_rpm.cmake
+++ b/targets/otc_fips_linux_arm64_rpm.cmake
@@ -1,0 +1,16 @@
+set(package_name "otelcol-sumo-fips")
+set(package_os "linux")
+set(package_arch "aarch64")
+set(goos "linux")
+set(goarch "arm64")
+set(fips 1)
+
+set_common_settings()
+set_otc_settings()
+set_common_rpm_settings()
+set_otc_rpm_settings()
+
+default_otc_linux_install()
+install_otc_service_systemd()
+
+build_rpm_cpack_config()


### PR DESCRIPTION
Adds packages (named `otelcol-sumo-fips`) containing fips binaries for otelcol-sumo & otelcol-config. I've configured the packages to ensure `otelcol-sumo` and `otelcol-sumo-fips` cannot be installed side-by-side on the same system. Users who want to switch between the binaries will need to first uninstall the currently installed package.

Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>