### PR TITLE
chore(install-script): show upgrade instructions

### DIFF
--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -88,6 +88,7 @@ USER_ENV_DIRECTORY=""
 UNINSTALL=""
 UPGRADE=""
 SUMO_BINARY_PATH=""
+SUMO_CONFIG_BINARY_PATH=""
 COMMON_CONFIG_PATH=""
 PURGE=""
 DOWNLOAD_ONLY=""
@@ -163,6 +164,7 @@ function set_defaults() {
     DOWNLOAD_CACHE_DIR="/var/cache/otelcol-sumo"  # this is in case we want to keep downloaded binaries
     CONFIG_DIRECTORY="/etc/otelcol-sumo"
     SUMO_BINARY_PATH="/usr/local/bin/otelcol-sumo"
+    SUMO_CONFIG_BINARY_PATH="/usr/local/bin/otelcol-config"
     USER_ENV_DIRECTORY="${CONFIG_DIRECTORY}/env"
     TOKEN_ENV_FILE="${USER_ENV_DIRECTORY}/token.env"
 
@@ -400,6 +402,9 @@ function verify_installation() {
         echo "WARNING: ${SUMO_BINARY_PATH} is not in \$PATH"
         otel_command="${SUMO_BINARY_PATH}"
     fi
+    if ! command -v otelcol-config; then
+        echo "WARNING: ${SUMO_CONFIG_BINARY_PATH} is not in \$PATH"
+    fi
     echo "Running ${otel_command} --version to verify installation"
     OUTPUT="$(${otel_command} --version || true)"
     readonly OUTPUT
@@ -473,7 +478,7 @@ function setup_config() {
 
     if [[ "${INSTALL_HOSTMETRICS}" == "true" ]]; then
         echo -e "Installing ${OS_TYPE} hostmetrics configuration"
-        otelcol-config --enable-hostmetrics
+        "${SUMO_CONFIG_BINARY_PATH}" --enable-hostmetrics
     fi
 
     ## Check if there is anything to update in configuration
@@ -534,7 +539,7 @@ function setup_config_darwin() {
 
     if [[ "${INSTALL_HOSTMETRICS}" == "true" ]]; then
         echo -e "Installing ${OS_TYPE} hostmetrics configuration"
-        otelcol-config --enable-hostmetrics
+        "${SUMO_CONFIG_BINARY_PATH}" --enable-hostmetrics
     fi
 }
 
@@ -594,7 +599,7 @@ function uninstall_darwin() {
 function uninstall_linux() {
     case $(get_package_manager) in
         yum | dnf)
-            yum remove --quiet -yes otelcol-sumo
+            yum remove --quiet -y otelcol-sumo
             ;;
         apt-get)
             if [[ "${PURGE}" == "true" ]]; then
@@ -648,8 +653,8 @@ function get_launchd_token() {
 }
 
 function get_user_api_url() {
-    if command -v otelcol-config &> /dev/null; then
-        KV=$(otelcol-config --read-kv .extensions.sumologic.api_base_url)
+    if command -v "${SUMO_CONFIG_BINARY_PATH}" &> /dev/null; then
+        KV=$("${SUMO_CONFIG_BINARY_PATH}" --read-kv .extensions.sumologic.api_base_url)
         if [[ "${KV}" != "null" ]]; then
             echo "${KV}"
         fi
@@ -657,8 +662,8 @@ function get_user_api_url() {
 }
 
 function get_user_opamp_endpoint() {
-    if command -v otelcol-config &> /dev/null; then
-        KV=$(otelcol-config --read-kv .extensions.opamp.endpoint)
+    if command -v "${SUMO_CONFIG_BINARY_PATH}" &> /dev/null; then
+        KV=$("${SUMO_CONFIG_BINARY_PATH}" --read-kv .extensions.opamp.endpoint)
         if [[ "${KV}" != "null" ]]; then
             echo "${KV}"
         fi
@@ -670,7 +675,7 @@ function write_installation_token() {
     local token
     readonly token="${1}"
 
-    otelcol-config --set-installation-token "$token"
+    "${SUMO_CONFIG_BINARY_PATH}" --set-installation-token "$token"
 }
 
 # write ${ENV_TOKEN} to launchd configuration file
@@ -707,7 +712,7 @@ function write_installation_token_launchd() {
 
 # write sumologic ephemeral: true to user configuration file
 function write_ephemeral_true() {
-    otelcol-config --enable-ephemeral
+    "${SUMO_CONFIG_BINARY_PATH}" --enable-ephemeral
 }
 
 # write api_url to user configuration file
@@ -715,7 +720,7 @@ function write_api_url() {
     local api_url
     readonly api_url="${1}"
 
-    otelcol-config --set-api-url "$api_url"
+    "${SUMO_CONFIG_BINARY_PATH}" --set-api-url "$api_url"
 }
 
 # write opamp endpoint to user configuration file
@@ -723,7 +728,7 @@ function write_opamp_endpoint() {
     local opamp_endpoint
     readonly opamp_endpoint="${1}"
 
-    otelcol-config --set-opamp-endpoint "$opamp_endpoint"
+    "${SUMO_CONFIG_BINARY_PATH}" --set-opamp-endpoint "$opamp_endpoint"
 }
 
 # write tags to user configuration file
@@ -731,13 +736,13 @@ function write_tags() {
     arr=("$@")
     for field in "${arr[@]}";
     do
-        otelcol-config --add-tag "$field"
+        "${SUMO_CONFIG_BINARY_PATH}" --add-tag "$field"
     done
 }
 
 # configure and enable the opamp extension for remote management
 function write_opamp_extension() {
-    otelcol-config --enable-remote-control
+    "${SUMO_CONFIG_BINARY_PATH}" --enable-remote-control
 }
 
 # NB: this function is only for Darwin
@@ -1031,9 +1036,9 @@ function get_user_token() {
 
   # Check yaml configuration for a token
   if [[ -z "${token}" ]]; then
-    if command -v otelcol-config &> /dev/null; then
+    if command -v "${SUMO_CONFIG_BINARY_PATH}" &> /dev/null; then
       local output=""
-      output=$(otelcol-config --read-kv .extensions.sumologic.installation_token)
+      output=$("${SUMO_CONFIG_BINARY_PATH}" --read-kv .extensions.sumologic.installation_token)
       if [[ "${output}" != "null" ]]; then
         token="${output}"
       fi

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -566,13 +566,12 @@ function upgrade() {
 function upgrade_linux() {
     case $(get_package_manager) in
         yum | dnf)
-            yum update --quiet -y
+            yum update otelcol-sumo --quiet -y
             ;;
         apt-get)
-            apt-get update --quiet && apt-get upgrade --quiet -y
+            apt-get update --quiet && apt-get upgrade otelcol-sumo --quiet -y
             ;;
     esac
-
 }
 
 # uninstall otelcol-sumo on darwin
@@ -880,6 +879,19 @@ function install_linux_package() {
     esac
 }
 
+function show_upgrade_instructions() {
+    echo -n "Upgrades can be performed using the native package manager: "
+
+    case $(get_package_manager) in
+        yum | dnf)
+            echo "yum update otelcol-sumo -y"
+            ;;
+        apt-get)
+            echo "apt-get update && apt-get upgrade otelcol-sumo -y"
+            ;;
+    esac
+}
+
 function check_deprecated_linux_flags() {
     if [[ -n "${BINARY_BRANCH}" ]]; then
         echo "warning: --binary-branch is deprecated"
@@ -895,7 +907,8 @@ function check_deprecated_linux_flags() {
     fi
 
     if [[ -n "${DOWNLOAD_ONLY}" ]]; then
-        echo "--download-only is only supported on darwin, use 'install.sh --upgrade' to upgrade otelcol-sumo"
+        echo "--download-only is only supported on darwin"
+        show_upgrade_instructions
         exit 1
     fi
 }
@@ -1178,6 +1191,12 @@ if has_prepackaging_installation; then
    # We can now proceed and install using the packages and attempt to restore
    # the configuration later.
    HAD_PREPACKAGING_INSTALLATION="true"
+fi
+
+if is_package_installed; then
+    echo "The otelcol-sumo package is already installed"
+    show_upgrade_instructions
+    exit 1
 fi
 
 install_linux_package "${package_name}"


### PR DESCRIPTION
* (Linux-only) Prevents installing over an existing package installation. Shows a message with instructions on how to upgrade.
* (Linux-only) Adds the package name to the upgrade commands.