### PR TITLE
Remove opamp config from sumologic.yaml

### DIFF
--- a/assets/sumologic.yaml
+++ b/assets/sumologic.yaml
@@ -23,13 +23,6 @@ extensions:
       on_rebound: true
     directory: /var/lib/otelcol-sumo/file_storage
 
-  ## Configuration for OpAMP Extension
-  ## The OpAMP extension remotely manages collector configuration.
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/opampextension
-  opamp:
-    remote_configuration_directory: /etc/otelcol-sumo/opamp.d
-    endpoint: wss://opamp-events.sumologic.com/v1/opamp
-
 receivers:
   ## Configuration for OTLP Receiver
   ## Receives data via gRPC or HTTP using OTLP format.


### PR DESCRIPTION
The opamp config is generated by otelcol-config and placed in a separate sumologic-remote.yaml file. Opamp configuration should not be in the non-remote config.