### PR TITLE
Remove common.yaml on *nix, check for capset

### DIFF
--- a/assets/deb/conffiles
+++ b/assets/deb/conffiles
@@ -1,3 +1,2 @@
 /etc/otelcol-sumo/sumologic.yaml
-/etc/otelcol-sumo/conf.d/common.yaml
 /etc/otelcol-sumo/env/token.env

--- a/ci/verify_installer.sh
+++ b/ci/verify_installer.sh
@@ -20,8 +20,7 @@ trap 'on_exit "$BASH_COMMAND" "$?" "$LINENO"' EXIT
 
 # verify the script is being run as root
 id="$(id -u)"
-if [ "$id" -ne "0" ]
-then
+if [ "$id" -ne "0" ]; then
   echo "Must be run as root to run this script"
   expected_error=1
   exit 1
@@ -47,7 +46,6 @@ system_files=(
 expected_collector_files=(
   "etc/otelcol-sumo"
   "etc/otelcol-sumo/conf.d"
-  "etc/otelcol-sumo/conf.d/common.yaml"
   "etc/otelcol-sumo/conf.d-available"
   "etc/otelcol-sumo/conf.d-available/ephemeral.yaml"
   "etc/otelcol-sumo/conf.d-available/hostmetrics.yaml"
@@ -78,7 +76,7 @@ function install_package() {
 
   # extract choices xml from meta package, override the choices to enable
   # optional choices, and then install using the new choice selections
-  installer -showChoiceChangesXML -pkg "$mpkg" -target / > "$choices_xml"
+  installer -showChoiceChangesXML -pkg "$mpkg" -target / >"$choices_xml"
   override_choices
   installer -applyChoiceChangesXML "$choices_xml" -pkg "$mpkg" -target /
 }
@@ -88,7 +86,7 @@ function override_choices() {
   count=$(plutil -convert raw -o - "$choices_xml")
 
   # loop through each installation choice
-  for (( j=0; j < "$count"; j++ )); do
+  for ((j = 0; j < "$count"; j++)); do
     choice_id_key="${j}.choiceIdentifier"
     choice_attr_key="${j}.choiceAttribute"
     attr_setting_key="${j}.attributeSetting"
@@ -175,13 +173,13 @@ cd "$expanded_dir" || exit
 
 # create an array of all packages
 all_pkgs=()
-while IFS=  read -r -d $'\0'; do
+while IFS= read -r -d $'\0'; do
   all_pkgs+=("$REPLY")
 done < <(find . -name "*.pkg" -type d -print0)
 
 # create an array of collector packages (only one is expected)
 collector_pkg=()
-while IFS=  read -r -d $'\0'; do
+while IFS= read -r -d $'\0'; do
   collector_pkg+=("$REPLY")
 done < <(find . -name "*-otelcol-sumo.pkg" -type d -print0)
 
@@ -205,7 +203,7 @@ fi
 collector_pkg_name="$(echo "${collector_pkg[0]}" | cut -d/ -f2-)"
 cd "${collector_pkg_name}/Payload" || exit
 all_collector_files=()
-while IFS=  read -r -d $'\0'; do
+while IFS= read -r -d $'\0'; do
   all_collector_files+=("$REPLY")
 done < <(find . ! -name '.' -print0)
 

--- a/components/otelcol-sumo.cmake
+++ b/components/otelcol-sumo.cmake
@@ -8,7 +8,6 @@ macro(default_otc_linux_install)
   install_otc_state_directory()
   install_otc_filestorage_state_directory()
   install_otc_sumologic_yaml()
-  install_otc_common_yaml()
   install_otc_linux_hostmetrics_yaml()
   install_otc_ephemeral_yaml()
   install_otc_token_env()
@@ -26,7 +25,6 @@ macro(default_otc_darwin_install)
   install_otc_filestorage_state_directory()
   install_otc_log_directory()
   install_otc_sumologic_yaml()
-  install_otc_common_yaml()
   install_otc_darwin_hostmetrics_yaml()
   install_otc_ephemeral_yaml()
   install_otc_binary()
@@ -284,22 +282,6 @@ macro(install_otc_token_env)
   install(
     FILES "${ASSETS_DIR}/env/token.env"
     DESTINATION "${OTC_USER_ENV_DIR}"
-    PERMISSIONS
-      OWNER_READ OWNER_WRITE
-      GROUP_READ GROUP_WRITE
-    COMPONENT otelcol-sumo
-  )
-endmacro()
-
-# e.g. /etc/otelcol-sumo/conf.d/common.yaml
-macro(install_otc_common_yaml)
-  require_variables(
-    "ASSETS_DIR"
-    "OTC_CONFIG_FRAGMENTS_DIR"
-  )
-  install(
-    FILES "${ASSETS_DIR}/conf.d/common.yaml"
-    DESTINATION "${OTC_CONFIG_FRAGMENTS_DIR}"
     PERMISSIONS
       OWNER_READ OWNER_WRITE
       GROUP_READ GROUP_WRITE

--- a/settings/rpm/otc.cmake
+++ b/settings/rpm/otc.cmake
@@ -10,7 +10,6 @@ macro(set_otc_rpm_settings)
     # Mark config files to prevent package upgrades from replacing the file by
     # default
     "%config(noreplace) /etc/otelcol-sumo/sumologic.yaml"
-    "%config(noreplace) /etc/otelcol-sumo/conf.d/common.yaml"
     "%config(noreplace) /etc/otelcol-sumo/env/token.env"
   )
 

--- a/templates/hooks/common/otc-linux-functions.in
+++ b/templates/hooks/common/otc-linux-functions.in
@@ -15,12 +15,24 @@ set_file_ownership()
 
 set_capabilities()
 {
-    echo -e "Setting the CAP_DAC_READ_SEARCH Linux capability on the " \
-        "collector binary to allow it to read host metrics from /proc " \
-        "directory: setcap 'cap_dac_read_search=ep' \"@OTC_BIN_PATH@\""
-    echo -e "You can remove it with the following command: " \
-        "sudo setcap -r \"@OTC_BIN_PATH@\""
-    echo -e "Without this capability, the collector will not be able to " \
-        "collect some of the host metrics."
-    setcap 'cap_dac_read_search=ep' "@OTC_BIN_PATH@"
+    if command -v setcap &> /dev/null; then
+        echo -e "Setting the CAP_DAC_READ_SEARCH Linux capability on the " \
+            "collector binary to allow it to read host metrics from the " \
+            "/proc directory: " \
+            "setcap 'cap_dac_read_search=ep' \"@OTC_BIN_PATH@\""
+        echo -e "You can remove it with the following command: " \
+            "sudo setcap -r \"@OTC_BIN_PATH@\""
+        echo -e "Without this capability, the collector will not be able to " \
+            "collect some of the host metrics."
+        setcap 'cap_dac_read_search=ep' "@OTC_BIN_PATH@"
+    else
+        echo -e "WARNING: setcap command not found"
+        echo -e "The CAP_DAC_READ_SEARCH Linux capability should be set on " \
+            "the collector binary to allow it to read host metrics from " \
+            "the /proc directory. It is recommended to install the setcap " \
+            "command and then run: " \
+            "sudo setcap 'cap_dac_read_search=ep' \"@OTC_BIN_PATH@\""
+        echo -e "Without this capability, the collector will not be able to " \
+            "collect some of the host metrics."
+    fi
 }


### PR DESCRIPTION
* Removes the unused `common.yaml` file on Linux & Darwin
* Check for `capset` command and display warning if it is not found

Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>