### PR TITLE
fix(install-script): fix unbounded variable & null check

### DIFF
--- a/install-script/install.ps1
+++ b/install-script/install.ps1
@@ -56,7 +56,7 @@ param (
 
 # If the environment variable SKIP_ARCH_DETECTION is set and is not
 # equal to "0" then set $SkipArchDetection to $True.
-if ($env:SKIP_ARCH_DETECTION -ne "" -and $env:SKIP_ARCH_DETECTION -ne "0") {
+if ($env:SKIP_ARCH_DETECTION -ne $null -and $env:SKIP_ARCH_DETECTION -ne "" -and $env:SKIP_ARCH_DETECTION -ne "0") {
     $SkipArchDetection = $True
 }
 
@@ -348,7 +348,7 @@ try {
         Write-Host "Detected architecture:`t${archName}"
     } else {
         if ($OverrideArch -eq "") {
-            Write-Error "OverrideArch flag must be set when using SkipArchDetection"
+            Write-Error "OverrideArch flag must be set when using SkipArchDetection" -ErrorAction Stop
         }
         Write-Host "Skipping architecture detection"
     }
@@ -370,7 +370,7 @@ try {
 
     if ($Fips -eq $true) {
         if ($osName -ne "Win32NT" -or $archName -ne "x64") {
-            Write-Error "Error: The FIPS-approved binary is only available for windows/amd64"
+            Write-Error "Error: The FIPS-approved binary is only available for windows/amd64" -ErrorAction Stop
         }
     }
 
@@ -451,7 +451,7 @@ try {
     }
     msiexec.exe /i "$msiPath" /passive $msiProperties
 } catch [HttpRequestException] {
-    Write-Error $_.Exception.InnerException.Message
+    Write-Error $_.Exception.InnerException.Message -ErrorAction Stop
 }
 
 Write-Host "Installation successful"

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -120,6 +120,11 @@ PACKAGECLOUD_ORG="${PACKAGECLOUD_ORG:-sumologic}"
 PACKAGECLOUD_REPO="${PACKAGECLOUD_REPO:-stable}"
 PACKAGECLOUD_MASTER_TOKEN="${PACKAGECLOUD_MASTER_TOKEN:-}"
 
+# Used to overwrite the download URL for the Darwin package. This is useful for
+# testing in CI where we have to be sure we're testing the package that was
+# built and not the latest package uploaded to S3.
+DARWIN_PKG_URL="${DARWIN_PKG_URL:-}"
+
 ############################ Functions
 
 function usage() {

--- a/install-script/test/install_darwin_test.go
+++ b/install-script/test/install_darwin_test.go
@@ -177,9 +177,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkGroupExists,
 				checkHomeDirectoryCreated,
 			},
-			// TODO(JK): this succeeds when testing locally but fails in CI,
-			// I need to determine why this is the case
-			installCode: 1,
+			installCode: 0,
 		},
 		{
 			name: "installation token, remotely-managed, and ephemeral",
@@ -204,9 +202,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkGroupExists,
 				checkHomeDirectoryCreated,
 			},
-			// TODO(JK): this succeeds when testing locally but fails in CI,
-			// I need to determine why this is the case
-			installCode: 1,
+			installCode: 0,
 		},
 		{
 			name: "same installation token in launchd config",


### PR DESCRIPTION
Fixes an unbounded variable error in `install.sh` and checks `$env:SKIP_ARCH_DETECTION` for `$null` in `install.ps1`