### PR TITLE
feat: add fedora 41, rm fedora 39

### DIFF
--- a/distributions/fedora.cmake
+++ b/distributions/fedora.cmake
@@ -9,10 +9,10 @@
 # Fedora only supports the last two releases.
 ##
 
-# Fedora 40
-function(fedora_40)
-  set(_distro_name "Fedora 40")
-  set(_distro_index_name "fedora/40")
+# Fedora 41
+function(fedora_41)
+  set(_distro_name "Fedora 41")
+  set(_distro_index_name "fedora/41")
   set(_supported_architectures
     "aarch64"
     "x86_64"
@@ -22,10 +22,10 @@ function(fedora_40)
   check_architecture_support()
 endfunction()
 
-# Fedora 39
-function(fedora_39)
-  set(_distro_name "Fedora 39")
-  set(_distro_index_name "fedora/39")
+# Fedora 40
+function(fedora_40)
+  set(_distro_name "Fedora 40")
+  set(_distro_index_name "fedora/40")
   set(_supported_architectures
     "aarch64"
     "x86_64"

--- a/targets/otc_fips_linux_amd64_rpm.cmake
+++ b/targets/otc_fips_linux_amd64_rpm.cmake
@@ -15,8 +15,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_39()
 fedora_40()
+fedora_41()
 
 # Supported openSUSE versions
 opensuse_15_5()

--- a/targets/otc_fips_linux_arm64_rpm.cmake
+++ b/targets/otc_fips_linux_arm64_rpm.cmake
@@ -15,8 +15,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_39()
 fedora_40()
+fedora_41()
 
 # Supported openSUSE versions
 opensuse_15_5()

--- a/targets/otc_linux_amd64_rpm.cmake
+++ b/targets/otc_linux_amd64_rpm.cmake
@@ -14,8 +14,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_39()
 fedora_40()
+fedora_41()
 
 # Supported openSUSE versions
 opensuse_15_5()

--- a/targets/otc_linux_arm64_rpm.cmake
+++ b/targets/otc_linux_arm64_rpm.cmake
@@ -14,8 +14,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_39()
 fedora_40()
+fedora_41()
 
 # Supported openSUSE versions
 opensuse_15_5()


### PR DESCRIPTION
Adds Fedora 41 to the list of Linux distributions we upload packages for. Removes Fedora 39 as Fedora only supports the last two releases.

Closes #132