### PR TITLE
fix(wix): set LoadOrderGroup

### DIFF
--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -91,7 +91,7 @@
         <!-- Add service for OTC -->
         <ServiceInstall Id="Service" Name="!(loc.ServiceName)" DisplayName="!(loc.ServiceDisplayName)"
           Description="!(loc.ServiceDescription)" Type="ownProcess" Vital="yes" Start="auto" Account="LocalSystem"
-          ErrorControl="normal" Arguments="[SERVICEARGUMENTS]" Interactive="no">
+          ErrorControl="normal" Arguments="[SERVICEARGUMENTS]" Interactive="no" LoadOrderGroup="NetworkProvider">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart"
             ThirdFailureActionType="restart" RestartServiceDelayInSeconds="0" ResetPeriodInDays="0" />
         </ServiceInstall>


### PR DESCRIPTION
Sets the LoadOrderGroup to require network connectivity before the service can start.