### PR TITLE
Use version artifacts with release workflow

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -59,6 +59,9 @@ on:
       otc_version:
         description: "The version of the package"
         value: ${{ jobs.build_package.outputs.otc_version }}
+      otc_sumo_version:
+        description: "The sumo version of the collector binary"
+        value: ${{ jobs.build_package.outputs.otc_sumo_version }}
       otc_build_number:
         description: "The build number of the package"
         value: ${{ jobs.build_package.outputs.otc_build_number }}
@@ -75,6 +78,7 @@ jobs:
     outputs:
       otc_version: ${{ steps.get-otc-version.outputs.otc_version }}
       otc_build_number: ${{ steps.get-build-number.outputs.otc_build_number }}
+      otc_sumo_version: ${{ steps.get-sumo-version.outputs.otc_sumo_version }}
       package_path: ${{ steps.package.outputs.path }}
     steps:
       - name: Checkout
@@ -147,6 +151,16 @@ jobs:
           version=$(./otelcol-sumo --version |
           sed -E -n 's/.* ([0-9]+\.[0-9]+\.[0-9]+)\-sumo.*/\1/p') &&
           echo otc_version="${version}" >> $GITHUB_OUTPUT &&
+          if [[ "$version" == "" ]]; then exit 1; fi
+
+      - name: Output Sumo Version
+        id: get-sumo-version
+        if: inputs.cmake_target == 'otc_linux_amd64_deb'
+        working-directory: build/version_detection
+        run: >
+          version=$(./otelcol-sumo --version |
+          sed -E -n 's/.* [0-9]+\.[0-9]+\.[0-9]+\-sumo-([0-9]+).*/\1/p') &&
+          echo otc_sumo_version="${version}" >> $GITHUB_OUTPUT &&
           if [[ "$version" == "" ]]; then exit 1; fi
 
       - name: Build Makefile

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -137,6 +137,45 @@ jobs:
             build_tool: wix
             fips: true
 
+  # Creates version files and uploads them as artifacts. This enables the
+  # release workflow to determine the version information for a given workflow.
+  version-files:
+    name: Create & upload version files
+    runs-on: ubuntu-latest
+    needs:
+      - build_packages
+    env:
+      OTC_VERSION: ${{ needs.build_packages.outputs.otc_version }}
+      OTC_BUILD_NUMBER: ${{ needs.build_packages.outputs.otc_build_number }}
+      OTC_SUMO_VERSION: ${{ needs.build_packages.outputs.otc_sumo_version }}
+    steps:
+      - name: Create version files
+        run: |
+          echo "${OTC_VERSION}" > otc-version.txt
+          echo "${OTC_BUILD_NUMBER}" > otc-build-number.txt
+          echo "${OTC_SUMO_VERSION}" > otc-sumo-version.txt
+
+      - name: Store otc-version.txt as action artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: otc-version.txt
+          path: ./otc-version.txt
+          if-no-files-found: error
+
+      - name: Store otc-build-number.txt as action artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: otc-build-number.txt
+          path: ./otc-build-number.txt
+          if-no-files-found: error
+
+      - name: Store otc-sumo-version.txt as action artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: otc-sumo-version.txt
+          path: ./otc-sumo-version.txt
+          if-no-files-found: error
+
   install-script:
     name: Store install script
     runs-on: ubuntu-latest

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -19,14 +19,15 @@ defaults:
 
 jobs:
   get-version:
-    name: Get application version for this revision
+    name: Get application version info for this revision
     runs-on: ubuntu-latest
     outputs:
       git-sha: ${{ steps.get-version.outputs.git-sha }}
-      otc-version: ${{ steps.get-version.outputs.otc-version }}
-      sumo-version: ${{ steps.get-version.outputs.sumo-version }}
-      binary-version: ${{ steps.get-version.outputs.binary-version }}
-      version: ${{ steps.get-version.outputs.version }}
+      otc-version: ${{ steps.set-versions.outputs.otc_version }}
+      otc-build-number: ${{ steps.set-versions.outputs.otc_build_number }}
+      otc-sumo-version: ${{ steps.set-versions.outputs.otc_sumo_version }}
+      package-version: ${{ steps.set-versions.outputs.package_version }}
+      binary-version: ${{ steps.set-versions.outputs.binary_version }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -41,50 +42,41 @@ jobs:
           url="${repo_url}/actions/runs/${{ inputs.workflow_id }}"
           echo ::notice title=Workflow URL::${url}
 
-      - name: Determine Workflow Run ID from workflow
-        id: get-run-number
-        run: |
-          workflow="11673248730"
-          run_number=$(gh run view "${workflow}" --json number -t '{{.number}}')
-          echo "run-number=$run_number" >> $GITHUB_OUTPUT
-
-      - name: Output Workflow Run Number
-        run: |
-          run_number=${{ steps.get-run-number.outputs.run-number }}
-          echo ::notice title=Workflow Run Number::${run_number}
-
-      - name: Download otelcol-sumo artifact from workflow
+      - name: Download version artifacts from workflow
         uses: actions/download-artifact@v4
         with:
-          name: otelcol-sumo-linux_amd64
+          pattern: "*.txt"
           path: artifacts/
           merge-multiple: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.workflow_id }}
 
-      - name: Determine version from artifact
-        id: get-version
+      - name: Set version outputs
+        id: set-versions
         run: |
-          artifact="artifacts/otelcol-sumo-linux_amd64"
-          chmod +x "${artifact}"
-          script="ci/get_version_from_binary.sh"
-          core="$("$script" core "${artifact}")"
-          sumo="$("$script" sumo "${artifact}")"
-          run_number=${{ steps.get-run-number.outputs.run-number }}
-          echo "otc-version=$core" >> $GITHUB_OUTPUT
-          echo "sumo-version=$sumo" >> $GITHUB_OUTPUT
-          echo "binary-version=${core}-sumo-${sumo}" >> $GITHUB_OUTPUT
-          echo "version=${core}-${run_number}" >> $GITHUB_OUTPUT
+          otc_version="$(cat artifacts/otc-version.txt)"
+          otc_build_number="$(cat artifacts/otc-build-number.txt)"
+          otc_sumo_version="$(cat artifacts/otc-sumo-version.txt)"
+          echo otc_version="${otc_version}" >> $GITHUB_OUTPUT
+          echo otc_build_number="${otc_build_number}" >> $GITHUB_OUTPUT
+          echo otc_sumo_version="${otc_sumo_version}" >> $GITHUB_OUTPUT
+          echo package_version="${otc_version}-${otc_build_number}" >> $GITHUB_OUTPUT
+          echo binary_version="${otc_version}-sumo-${otc_sumo_version}" >> $GITHUB_OUTPUT
 
-      - name: Output Binary Version
+      - name: Output OTC Version
         run: |
-          binary_version=${{ steps.get-version.outputs.binary-version }}
-          echo ::notice title=Binary Version::${binary_version}
+          version="${{ steps.set-versions.outputs.otc_version }}"
+          echo ::notice title=OTC Version::${version}
 
-      - name: Output Package Version
+      - name: Output OTC Build Number
         run: |
-          package_version=${{ steps.get-version.outputs.version }}
-          echo ::notice title=Package Version::${package_version}
+          version="${{ steps.set-versions.outputs.otc_build_number }}"
+          echo ::notice title=OTC Build Number::${version}
+
+      - name: Output OTC Sumo Version
+        run: |
+          version=${{ steps.set-version.outputs.otc_sumo_version }}
+          echo ::notice title=OTC Sumo Version::${version}
 
       - name: Determine Git SHA of workflow
         id: get-sha
@@ -141,11 +133,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.workflow_id }}
 
+      - name: List all artifacts
+        run: ls -l artifacts/
+
       - uses: ncipollo/release-action@v1
         with:
-          name: v${{ needs.get-version.outputs.version }}
+          name: v${{ needs.get-version.outputs.package-version }}
           commit: ${{ needs.get-version.outputs.git-sha }}
-          tag: v${{ needs.get-version.outputs.version }}
+          tag: v${{ needs.get-version.outputs.package-version }}
 
           draft: true
           generateReleaseNotes: true
@@ -155,16 +150,11 @@ jobs:
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
 
-          artifacts: "artifacts/*/*"
+          artifacts: "artifacts/*"
           artifactErrorsFailBuild: true
-          replacesArtifacts: true
+          replacesArtifacts: false
 
           body: |
-            This release packages
-            [${{ needs.get-version.outputs.version }}](https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v${{ needs.get-version.outputs.binary-version }}).
+            This release packages Sumo Logic Distributions for OpenTelemetry Collector [${{ needs.get-version.outputs.binary-version }}](https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v${{ needs.get-version.outputs.binary-version }}).
 
-            The changelog below is for the package itself, rather than the Sumo
-            Logic Distribution for OpenTelemetry Collector. The changelog for
-            the Sumo Logic Distribution for OpenTelemetry Collector can be found
-            on the collector's
-            [release page](https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v${{ needs.get-version.outputs.binary-version }}).
+            The changelog below is for the package itself, rather than the Sumo Logic Distribution for OpenTelemetry Collector. The changelog for the Sumo Logic Distribution for OpenTelemetry Collector can be found on the collector's [release page](https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v${{ needs.get-version.outputs.binary-version }}).


### PR DESCRIPTION
Adds version artifacts to the build workflow so that the release workflow can use version information to generate the release.

Draft release built using the fixed releases workflow: https://github.com/SumoLogic/sumologic-otel-collector-packaging/releases/tag/untagged-964d375434d9c7be36ff