### PR TITLE
chore(ci): use ubuntu-24.04 runner

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   determine_workflow:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Determine workflow_id
     outputs:
       workflow_id: ${{ steps.workflow.outputs.id }}
@@ -95,16 +95,16 @@ jobs:
       matrix:
         include:
           - target: otc_linux_amd64_deb
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_linux_amd64_rpm
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_linux_arm64_deb
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_linux_arm64_rpm
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_darwin_amd64_productbuild
             runs_on: macos-latest
@@ -119,16 +119,16 @@ jobs:
             build_tool: wix
           # fips targets
           - target: otc_fips_linux_amd64_deb
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_fips_linux_amd64_rpm
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_fips_linux_arm64_deb
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_fips_linux_arm64_rpm
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-24.04
             build_tool: cmake
           - target: otc_fips_windows_amd64_wix
             runs_on: windows-2019
@@ -139,7 +139,7 @@ jobs:
 
   install-script:
     name: Store install script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build_packages
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   get-version:
     name: Get application version for this revision
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       git-sha: ${{ steps.get-version.outputs.git-sha }}
       otc-version: ${{ steps.get-version.outputs.otc-version }}
@@ -103,7 +103,7 @@ jobs:
   # artifact.
   install-script:
     name: Store install script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - get-version
     steps:


### PR DESCRIPTION
The following warnings are being produced by every CI run:
```
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
```

We can get around this by setting the runner version explicitly.