### PR TITLE
fix(install-script): fix fips uninstaller

### DIFF
--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -626,13 +626,13 @@ function uninstall_darwin() {
 function uninstall_linux() {
     case $(get_package_manager) in
         yum | dnf)
-            yum remove --quiet -y otelcol-sumo
+            yum remove --quiet -y "${package_name}"
             ;;
         apt-get)
             if [[ "${PURGE}" == "true" ]]; then
-                apt-get purge --quiet -y otelcol-sumo
+                apt-get purge --quiet -y "${package_name}"
             else
-                apt-get remove --quiet -y otelcol-sumo
+                apt-get remove --quiet -y "${package_name}"
             fi
             ;;
     esac


### PR DESCRIPTION
This commit fixes an issue in the install script where the fips package can be installed and upgraded, but not removed, as the specified package name is incorrect in the uninstall function.

Fixes #145 