### PR TITLE
chore: update ubuntu runners to 24.04

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -141,7 +141,7 @@ jobs:
   # release workflow to determine the version information for a given workflow.
   version-files:
     name: Create & upload version files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build_packages
     env:
@@ -233,7 +233,7 @@ jobs:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs_on: ubuntu-20.04
+            runs_on: ubuntu-24.04
           - arch_os: darwin_amd64
             runs_on: macos-latest
           - arch_os: windows_amd64

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -119,7 +119,7 @@ jobs:
 
   create-release:
     name: Create Github release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - get-version
     permissions:


### PR DESCRIPTION
The Ubuntu 20.04 runners will stop functioning this week. These changes pin our runners to Ubuntu 24.04.