### PR TITLE
feat: add fedora 42, rm fedora 40

### DIFF
--- a/distributions/fedora.cmake
+++ b/distributions/fedora.cmake
@@ -9,10 +9,10 @@
 # Fedora only supports the last two releases.
 ##
 
-# Fedora 41
-function(fedora_41)
-  set(_distro_name "Fedora 41")
-  set(_distro_index_name "fedora/41")
+# Fedora 42
+function(fedora_42)
+  set(_distro_name "Fedora 42")
+  set(_distro_index_name "fedora/42")
   set(_supported_architectures
     "aarch64"
     "x86_64"
@@ -22,10 +22,10 @@ function(fedora_41)
   check_architecture_support()
 endfunction()
 
-# Fedora 40
-function(fedora_40)
-  set(_distro_name "Fedora 40")
-  set(_distro_index_name "fedora/40")
+# Fedora 41
+function(fedora_41)
+  set(_distro_name "Fedora 41")
+  set(_distro_index_name "fedora/41")
   set(_supported_architectures
     "aarch64"
     "x86_64"

--- a/targets/otc_fips_linux_amd64_rpm.cmake
+++ b/targets/otc_fips_linux_amd64_rpm.cmake
@@ -15,8 +15,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_40()
 fedora_41()
+fedora_42()
 
 # Supported openSUSE versions
 opensuse_15_5()

--- a/targets/otc_fips_linux_arm64_rpm.cmake
+++ b/targets/otc_fips_linux_arm64_rpm.cmake
@@ -15,8 +15,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_40()
 fedora_41()
+fedora_42()
 
 # Supported openSUSE versions
 opensuse_15_5()

--- a/targets/otc_linux_amd64_rpm.cmake
+++ b/targets/otc_linux_amd64_rpm.cmake
@@ -14,8 +14,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_40()
 fedora_41()
+fedora_42()
 
 # Supported openSUSE versions
 opensuse_15_5()

--- a/targets/otc_linux_arm64_rpm.cmake
+++ b/targets/otc_linux_arm64_rpm.cmake
@@ -14,8 +14,8 @@ el_8()
 el_9()
 
 # Supported Fedora versions
-fedora_40()
 fedora_41()
+fedora_42()
 
 # Supported openSUSE versions
 opensuse_15_5()


### PR DESCRIPTION
Adds Fedora 42 to the list of Linux distributions we upload packages for. Removes Fedora 40 as Fedora only supports the last two releases.