### PR TITLE
docs: add promotion docs

### DIFF
--- a/docs/release-candidate.md
+++ b/docs/release-candidate.md
@@ -1,0 +1,88 @@
+# Release Candidates
+
+## Promote packages & artifacts
+
+Perform the following steps to promote packages & artifacts from the `ci-builds`
+channel to the `release-candidates` channel.
+
+It is **important** to perform these steps **in order**.
+
+### Update latest CI builds version
+
+Each channel in Amazon S3 requires a `latest_version` file to point to a version
+that exists in that channel. This `latest_version` file is used by the install
+script to determine the latest available version on macOS and Windows systems.
+As the version that is being promoted will no longer be available in the CI
+builds channel, the `latest_version` file must first be updated to a
+previously available version.
+
+#### Determine previous CI builds version
+
+Packagecloud promotion removes packages from the source repository where as
+promotion in Amazon S3 does not. As a result the previous version should be
+determined from Packagecloud.
+
+1. Browse to the [ci-builds repository][pc_ci_builds] on the
+Packagecloud website.
+
+1. Packages are listed by most recently uploaded. The previous version can be
+found by scrolling through the list of packages until the version previous to
+the version to be released is found. There will likely be several pages to
+scroll through before finding the previous version. E.g. If the version being
+released is `0.124.0-2054` the previous CI build version could be
+`0.124.0-2030`.
+
+#### Update the latest version file
+
+Run the following commands to update the latest version file in the CI builds
+bucket. Be sure to change the version in the `echo` command to the previous
+CI build version from the previous step.
+
+```shell
+echo '0.124.0-2030' > latest_version
+aws s3 cp latest_version s3://sumologic-osc-ci-builds/latest_version --content-type text/plain
+```
+
+### Promote the packages
+
+1. Browse to the [ci-builds repository][pc_ci_builds].
+
+1. Use the search bar at the top of the page to search for the version to
+promote (e.g. `0.124.0-2054`). There should be around 4 pages of results.
+
+1. Click the checkbox to select all packages on the page.
+
+1. Click `promote`.
+
+1. Select `sumologic/release-candidates`.
+
+1. Click `Promote X packages` where X is the number of packages being promoted.
+
+1. Refresh the page and repeat the previous steps until there are no more
+packages to left to promote.
+
+### Promote the artifacts
+
+Now that the new packages are available in the release candidates channel in
+Packagecloud, the artifacts in the Amazon S3 CI builds bucket can be promoted.
+Run the following command, replacing the value for `VERSION` with the version to
+be promoted:
+
+```shell
+export VERSION="0.124.0-2054"
+aws s3 cp --recursive "s3://sumologic-osc-ci-builds/${VERSION}/" "s3://sumologic-osc-release-candidates/${VERSION}/"
+```
+
+### Update latest release candidate version
+
+All of the packages and artifacts have been promoted. It is now safe to update
+the `latest_version` file in the release candidates channel. Run the following
+command, replacing the version in the `echo` command to the version to be
+promoted:
+
+```shell
+echo '0.124.0-2054' > latest_version
+aws s3 cp latest_version s3://sumologic-osc-release-candidates/latest_version --content-type text/plain
+```
+
+[pc_ci_builds]: https://packagecloud.io/sumologic/ci-builds

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,17 +1,106 @@
 # Releasing
 
-## How to release
-
-### Check end-to-end tests
+## Check end-to-end tests
 
 Check if the Sumo internal e2e tests are passing.
 
+We can begin the process of creating a release once the QE team has given a
+thumbs up for a given package version.
+
+## Perform Collector release steps
+
+Perform the [collector release steps][collector_release] first to release the
+Collector binaries.
+
+## Promote packages & artifacts
+
+Perform the following steps to promote packages & artifacts from the
+`release-candidates` channel to the `stable` channel.
+
+It is **important** to perform these steps **in order**.
+
+### Update latest release candidate version
+
+Each channel in Amazon S3 requires a `latest_version` file to point to a version
+that exists in that channel. This `latest_version` file is used by the install
+script to determine the latest available version on macOS and Windows systems.
+As the version that is being promoted will no longer be available in the release
+candidates channel, the `latest_version` file must first be updated to a
+previously available version.
+
+#### Determine previous release candidate version
+
+Packagecloud promotion removes packages from the source repository where as
+promotion in Amazon S3 does not. As a result the previous version should be
+determined from Packagecloud.
+
+1. Browse to the [release-candidates repository][pc_release_candidates] on the
+Packagecloud website.
+
+1. Packages are listed by most recently uploaded. The previous version can be
+found by scrolling through the list of packages until the version previous to
+the version to be released is found. There will likely be several pages to
+scroll through before finding the previous version. E.g. If the version being
+released is `0.124.0-2054` the previous release candidate version could be
+`0.124.0-2030`.
+
+#### Update the latest version file
+
+Run the following commands to update the latest version file in the release
+candidates bucket. Be sure to change the version in the `echo` command to the
+previous release candidate version from the previous step.
+
+```shell
+echo '0.124.0-2030' > latest_version
+aws s3 cp latest_version s3://sumologic-osc-release-candidates/latest_version --content-type text/plain
+```
+
+### Promote the packages
+
+1. Browse to the [release-candidates repository][pc_release_candidates].
+
+1. Use the search bar at the top of the page to search for the version to
+promote (e.g. `0.124.0-2054`). There should be around 4 pages of results.
+
+1. Click the checkbox to select all packages on the page.
+
+1. Click `promote`.
+
+1. Select `sumologic/stable`.
+
+1. Click `Promote X packages` where X is the number of packages being promoted.
+
+1. Refresh the page and repeat the previous steps until there are no more
+packages to left to promote.
+
+### Promote the artifacts
+
+Now that the new packages are available in the stable channel in Packagecloud,
+the artifacts in the Amazon S3 release candidates bucket can be promoted. Run
+the following command, replacing the value for `VERSION` with the version to be
+promoted:
+
+```shell
+export VERSION="0.124.0-2054"
+aws s3 cp --recursive "s3://sumologic-osc-release-candidates/${VERSION}/" "s3://sumologic-osc-stable/${VERSION}/"
+```
+
+### Update latest stable version
+
+All of the packages and artifacts have been promoted. It is now safe to update
+the `latest_version` file in the stable channel. Run the following command,
+replacing the version in the `echo` command to the version to be promoted:
+
+```shell
+echo '0.124.0-2054' > latest_version
+aws s3 cp latest_version s3://sumologic-osc-stable/latest_version --content-type text/plain
+```
+
+## Create a GitHub Release
+
 ### Determine the Workflow Run ID to release
 
-We can begin the process of creating a release once QE has given a thumbs up for
-a given package version and the [collector release steps][collector_release]
-have already been performed. We can determine the Workflow Run ID to use for a
-release using the following steps:
+We can determine the Workflow Run ID to use for a release using the following steps.
 
 #### Find the package build number
 
@@ -29,7 +118,7 @@ workflow run in GitHub Actions. Unfortunately, there does not currently appear t
 be a way to reference a workflow run using the run number. Instead, we can use
 one of two methods to find the workflow run:
 
-#### Option 1 - Use the `gh` cli tool to find the workflow
+##### Option 1 - Use the `gh` cli tool to find the workflow
 
 ```shell
 PAGER=""; BUILD_NUMBER="1790"; \
@@ -54,7 +143,7 @@ the packages.
 
 The workflow run can be viewed by visiting the URL in the `url` field.
 
-#### Option 2 - Search the GitHub website manually
+##### Option 2 - Search the GitHub website manually
 
 Manually search for the run number on the
 [Build packages workflow][build_workflow] page. Search for the build number
@@ -116,6 +205,7 @@ After verifying that the release text and all links are good, publish the releas
 [build_workflow]: https://github.com/SumoLogic/sumologic-otel-collector-packaging/actions/workflows/build_packages.yml?query=branch%3Amain
 [changelog]: https://github.com/SumoLogic/sumologic-otel-collector/blob/main/CHANGELOG.md
 [collector_release]: https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/release.md
+[pc_release_candidates]: https://packagecloud.io/sumologic/release-candidates
 [release_0]: ../images/release_0.png
 [release_1]: ../images/release_1.png
 [release_1]: ../images/release_2.png


### PR DESCRIPTION
Adds documentation for the package & artifact promotion from `ci-builds` to `release-candidates` and from `release-candidates` to `stable`.