### PR TITLE
bug: add timezone for linux remotely managed collector

### DIFF
--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -463,6 +463,9 @@ function setup_config() {
     echo 'We are going to get and set up a default configuration for you'
 
     echo "Generating configuration and saving it in ${CONFIG_DIRECTORY}"
+    if [[ -n "${TIMEZONE}" ]]; then
+                write_timezone "${TIMEZONE}"
+    fi
     if [[ "${REMOTELY_MANAGED}" == "true" ]]; then
         write_opamp_extension
 
@@ -489,10 +492,6 @@ function setup_config() {
         # Return/stop function execution early as remaining logic only applies
         # to locally-managed installations
         return
-    fi
-
-    if [[ -n "${TIMEZONE}" ]]; then
-            write_timezone "${TIMEZONE}"
     fi
 
     if [[ "${INSTALL_HOSTMETRICS}" == "true" ]]; then


### PR DESCRIPTION
current set timezone logic for linux only executes for locally managed collector, making it common for both local and remote 

**Mac Remotely managed**

<img width="1312" height="813" alt="Screenshot 2025-09-01 at 1 39 15 PM" src="https://github.com/user-attachments/assets/70153834-2da7-4097-b30f-c9276c364720" />



**Mac locally managed**
<img width="1312" height="813" alt="Screenshot 2025-09-01 at 1 44 30 PM" src="https://github.com/user-attachments/assets/cc5ddff5-c773-48d9-88e6-dcb4fed22575" />


**Linux remote**
<img width="1312" height="813" alt="Screenshot 2025-09-01 at 1 51 29 PM" src="https://github.com/user-attachments/assets/848aa8d1-65d3-4948-9971-d951b8046184" />


**Linux Local**

<img width="1312" height="813" alt="Screenshot 2025-09-01 at 1 56 03 PM" src="https://github.com/user-attachments/assets/7e83bfb6-14ef-42ff-82ee-dafcb151d1a1" />

