### PR TITLE
ci: set environment variables required for promotion

### DIFF
--- a/.github/workflows/workflow-promote.yml
+++ b/.github/workflows/workflow-promote.yml
@@ -37,6 +37,8 @@ jobs:
     name: Promote
     runs-on: ubuntu-24.04
     env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow-promote.yml
+++ b/.github/workflows/workflow-promote.yml
@@ -36,6 +36,8 @@ jobs:
   promote:
     name: Promote
     runs-on: ubuntu-24.04
+    env:
+      PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Sets the environment variables required for promotion in CI:
* `PACKAGECLOUD_TOKEN`
* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY`

I used this branch to successfully promote `0.133.0-2274`: https://github.com/SumoLogic/sumologic-otel-collector-packaging/actions/runs/17627597925/job/50088155978