### PR TITLE
ci: always set latest_version in destination repo

### DIFF
--- a/.github/workflows/workflow-promote.yml
+++ b/.github/workflows/workflow-promote.yml
@@ -139,22 +139,17 @@ jobs:
 
           echo "version=$(cat version)" >> "$GITHUB_OUTPUT"
 
-      - name: Compare version to latest (destination channel)
-        id: compare-destination
-        run: |
-          version="${{ inputs.version }}"
-          latest="${{ steps.latest-destination.outputs.version }}"
-          packagecloud versions compare "${version}" "${latest}" | tee result
-
-          echo "result=$(cat result)" >> "$GITHUB_OUTPUT"
-
-      # NOTE: If the version we're trying to promote doesn't match the latest
-      # version available in the destination repository then we can skip
-      # updating the latest_version file in the destination repository.
+      # NOTE: Always set the latest_version file in the destination bucket to
+      # to the latest version found in the destination Packagecloud repository.
+      # The latest version won't always match what is being promoted. This
+      # ensures that re-running the promotion workflow will fix cases where
+      # latest_version in the destination bucket does not match the latest
+      # package version in the destination Packagecloud repository. This can
+      # only happen if the workflow fails before updating latest_version in the
+      # destination bucket but after one or more packages have been promoted.
       - name: Set latest version to latest (destination channel)
-        if: steps.compare-destination.outputs.result == 'greater'
         run: |
-          version="${{ inputs.version }}"
+          version="${{ steps.latest-destination.outputs.version }}"
           channel="${{ inputs.destination-channel }}"
           bucket="sumologic-osc-${channel}"
           file="latest_version"


### PR DESCRIPTION
Update the promotion workflow to always set the `latest_version` file to the latest version available in Packagecloud. This fixes an edge case where the `latest_version` file in the destination bucket won't match the latest package version available in Packagecloud. The edge case can occur if the promotion workflow fails after successfully promoting one or more packages but a failure occurs before the `latest_version` file is updated in the destination bucket.

This happened yesterday; promotion succeeded for packages in Packagecloud but S3 promotion failed.
Failed promotion: https://github.com/SumoLogic/sumologic-otel-collector-packaging/actions/runs/17627423901
Successful promotion: https://github.com/SumoLogic/sumologic-otel-collector-packaging/actions/runs/17627597925

The `latest_version` file was never updated after the successful promotion.