### PR TITLE
fix(ci): overwrite previous latest_version content

### DIFF
--- a/.github/workflows/workflow-promote.yml
+++ b/.github/workflows/workflow-promote.yml
@@ -109,7 +109,7 @@ jobs:
           file="latest_version"
           uri="s3://${bucket}/${file}"
 
-          echo "${previous}" >> "${file}"
+          echo "${previous}" > "${file}"
           aws s3 cp "${file}" "${uri}" --content-type plain
 
       - name: Promote packages
@@ -155,5 +155,5 @@ jobs:
           file="latest_version"
           uri="s3://${bucket}/${file}"
 
-          echo "${version}" >> "${file}"
+          echo "${version}" > "${file}"
           aws s3 cp "${file}" "${uri}" --content-type plain


### PR DESCRIPTION
The promote workflows currently use the append operator `>>` instead of the redirect operator `>` to write the latest version to the `latest_version` file. This creates an issue for the destination bucket as there is already content in the `latest_version` file from when we update the source bucket. This PR fixes that behaviour.