### PR TITLE
bug:adding timezone support for linux

### DIFF
--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -495,9 +495,9 @@ function setup_config() {
             write_tags "${FIELDS[@]}"
         fi
 
-       if [[ -n "${TIMEZONE}" ]]; then
+        if [[ -n "${TIMEZONE}" ]]; then
             write_timezone "${TIMEZONE}"
-       fi
+        fi
 
         # Return/stop function execution early as remaining logic only applies
         # to locally-managed installations

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -530,7 +530,7 @@ function setup_config() {
         fi
 
         if [[ -n "${TIMEZONE}" ]]; then
-           write_timezone "${TIMEZONE}"
+            write_timezone "${TIMEZONE}"
         fi
     fi
 }

--- a/install-script/install.sh
+++ b/install-script/install.sh
@@ -472,9 +472,6 @@ function setup_config() {
     echo 'We are going to get and set up a default configuration for you'
 
     echo "Generating configuration and saving it in ${CONFIG_DIRECTORY}"
-    if [[ -n "${TIMEZONE}" ]]; then
-                write_timezone "${TIMEZONE}"
-    fi
     if [[ "${REMOTELY_MANAGED}" == "true" ]]; then
         write_opamp_extension
 
@@ -498,6 +495,10 @@ function setup_config() {
             write_tags "${FIELDS[@]}"
         fi
 
+       if [[ -n "${TIMEZONE}" ]]; then
+            write_timezone "${TIMEZONE}"
+       fi
+
         # Return/stop function execution early as remaining logic only applies
         # to locally-managed installations
         return
@@ -509,7 +510,7 @@ function setup_config() {
     fi
 
     ## Check if there is anything to update in configuration
-    if [[ -n "${SUMOLOGIC_INSTALLATION_TOKEN}" || -n "${API_BASE_URL}" || ${#FIELDS[@]} -ne 0 || "${EPHEMERAL}" == "true" ]]; then
+    if [[ -n "${SUMOLOGIC_INSTALLATION_TOKEN}" || -n "${API_BASE_URL}" || ${#FIELDS[@]} -ne 0 || "${EPHEMERAL}" == "true" || -n "${TIMEZONE}" ]]; then
         USER_TOKEN="$(get_user_token)"
 
         if [[ -n "${SUMOLOGIC_INSTALLATION_TOKEN}" && -z "${USER_TOKEN}" ]]; then
@@ -526,6 +527,10 @@ function setup_config() {
 
         if [[ ${#FIELDS[@]} -gt 0 ]]; then
             write_tags "${FIELDS[@]}"
+        fi
+
+        if [[ -n "${TIMEZONE}" ]]; then
+           write_timezone "${TIMEZONE}"
         fi
     fi
 }


### PR DESCRIPTION
Recording write timezone for linux 

**Remote New Machine**

[ec2-user@ip-172-31-41-12 ~]$ cat ./install.sh | SUMOLOGIC_INSTALLATION_TOKEN="U1VNT0w1aWs2bzJoVHI0ZXdkNjVoQ3FKVDhVc1FWTnBodHRwczovL3N0YWctZXZlbnRzLnN1bW9sb2dpYy5uZXQ=" sudo -E bash -s -- --remotely-managed --tag "host.group=default" --tag "deployment.environment=default" --api https://stag-open-events.sumologic.net/ --opamp-api wss://stag-opamp-events.sumologic.net/v1/opamp --timezone Asia/Kolkata -v 0.130.1-2196
DOWNLOAD_URI = https://download-otel.sumologic.com
Detected OS type:       linux
Detected architecture:  amd64
Version specified: 0.130.1-2196
Detected operating system as amzn/2023.
Checking for curl...
Detected curl...
Downloading repository file: https://packages.sumologic.com/install/repositories/sumologic/stable/config_file.repo?os=amzn&dist=2023&source=script
done.
Installing yum-utils...
Amazon Linux 2023 Kernel Livepatch repository                                        211 kB/s |  23 kB     00:00    
sumologic_stable-source                                                              337  B/s | 833  B     00:02    
sumologic_stable-source                                                              5.4 kB/s | 3.9 kB     00:00    
Importing GPG key 0xD5A2FA16:
 Userid     : "https://packagecloud.io/sumologic/stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: F856 B440 4A86 50E3 58A4 8545 ED0D EF9C D5A2 FA16
 From       : https://packages.sumologic.com/sumologic/stable/gpgkey
sumologic_stable-source                                                               97  B/s | 296  B     00:03    
Package dnf-utils-4.3.0-13.amzn2023.0.5.noarch is already installed.
Dependencies resolved.
Nothing to do.
Complete!

WARNING: 
The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features.

Generating yum cache for sumologic_stable...
Importing GPG key 0xD5A2FA16:
 Userid     : "https://packagecloud.io/sumologic/stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: F856 B440 4A86 50E3 58A4 8545 ED0D EF9C D5A2 FA16
 From       : https://packages.sumologic.com/sumologic/stable/gpgkey
Generating yum cache for sumologic_stable-source...

The repository is setup! You can now install packages.
Installing otelcol-sumo-0.130.1-2196

Installed:
  otelcol-sumo-0.130.1-2196.x86_64                                                                                   

/usr/local/bin/otelcol-sumo
/usr/local/bin/otelcol-config
Running otelcol-sumo --version to verify installation
Installation succeded:  otelcol-sumo version 0.130.1-sumo-0-9cd0cff3fd63f4db526097a355ef9672f0956027
We are going to get and set up a default configuration for you
Generating configuration and saving it in /etc/otelcol-sumo
Reloading systemd
Enable otelcol-sumo service
Created symlink /etc/systemd/system/multi-user.target.wants/otelcol-sumo.service → /usr/lib/systemd/system/otelcol-sumo.service.
Starting otelcol-sumo service
[ec2-user@ip-172-31-41-12 ~]$  sudo cat /etc/otelcol-sumo/sumologic-remote.yaml
exporters:
  nop: {}
extensions:
  file_storage:
    compaction:
      directory: /var/lib/otelcol-sumo/file_storage
      on_rebound: true
    directory: /var/lib/otelcol-sumo/file_storage
  health_check:
    endpoint: localhost:13133
  opamp:
    endpoint: wss://stag-opamp-events.sumologic.net/v1/opamp
    remote_configuration_directory: /etc/otelcol-sumo/opamp.d
  sumologic:
    collector_credentials_directory: /var/lib/otelcol-sumo/credentials
    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
    time_zone: Asia/Kolkata
    api_base_url: https://stag-open-events.sumologic.net/
    collector_fields:
      host.group: default
      deployment.environment: default
receivers:
  nop: {}
service:
  extensions:
    - sumologic
    - health_check
    - file_storage
    - opamp
  pipelines:
    logs/default:
      exporters:
        - nop
      receivers:
        - nop
    metrics/default:
      exporters:
        - nop
      receivers:
        - nop
    traces/default:
      exporters:
        - nop
      receivers:
        - nop


**Remote Re Register**
[ec2-user@ip-172-31-41-12 ~]$ curl -sL https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector-packaging/refs/heads/main/install-script/install.sh | sudo -E bash -s -- -u -y -p
DOWNLOAD_URI = https://download-otel.sumologic.com
Detected OS type:       linux
Detected architecture:  amd64

Removed:
  otelcol-sumo-0.130.1-2196.x86_64                                                                                   

Uninstallation completed
[ec2-user@ip-172-31-41-12 ~]$ sudo rm -rf /var/lib/otelcol-sumo/credentials
[ec2-user@ip-172-31-41-12 ~]$  sudo rm -rf /var/cache/otelcol-sumo
[ec2-user@ip-172-31-41-12 ~]$ cat ./install.sh | SUMOLOGIC_INSTALLATION_TOKEN="U1VNT0w1aWs2bzJoVHI0ZXdkNjVoQ3FKVDhVc1FWTnBodHRwczovL3N0YWctZXZlbnRzLnN1bW9sb2dpYy5uZXQ=" sudo -E bash -s -- --remotely-managed --tag "host.group=default" --tag "deployment.environment=default" --api https://stag-open-events.sumologic.net/ --opamp-api wss://stag-opamp-events.sumologic.net/v1/opamp --timezone Asia/Kolkata -v 0.130.1-2196
DOWNLOAD_URI = https://download-otel.sumologic.com
Detected OS type:       linux
Detected architecture:  amd64
Version specified: 0.130.1-2196
Detected operating system as amzn/2023.
Checking for curl...
Detected curl...
Downloading repository file: https://packages.sumologic.com/install/repositories/sumologic/stable/config_file.repo?os=amzn&dist=2023&source=script
done.
Installing yum-utils...
sumologic_stable-source                                                              383  B/s | 833  B     00:02    
Package dnf-utils-4.3.0-13.amzn2023.0.5.noarch is already installed.
Dependencies resolved.
Nothing to do.
Complete!

WARNING: 
The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features.

Generating yum cache for sumologic_stable...
Generating yum cache for sumologic_stable-source...

The repository is setup! You can now install packages.
Installing otelcol-sumo-0.130.1-2196

Installed:
  otelcol-sumo-0.130.1-2196.x86_64                                                                                   

/usr/local/bin/otelcol-sumo
/usr/local/bin/otelcol-config
Running otelcol-sumo --version to verify installation
Installation succeded:  otelcol-sumo version 0.130.1-sumo-0-9cd0cff3fd63f4db526097a355ef9672f0956027
We are going to get and set up a default configuration for you
Generating configuration and saving it in /etc/otelcol-sumo
Reloading systemd
Enable otelcol-sumo service
Starting otelcol-sumo service
[ec2-user@ip-172-31-41-12 ~]$  sudo cat /etc/otelcol-sumo/sumologic-remote.yaml
exporters:
  nop: {}
extensions:
  file_storage:
    compaction:
      directory: /var/lib/otelcol-sumo/file_storage
      on_rebound: true
    directory: /var/lib/otelcol-sumo/file_storage
  health_check:
    endpoint: localhost:13133
  opamp:
    endpoint: wss://stag-opamp-events.sumologic.net/v1/opamp
    remote_configuration_directory: /etc/otelcol-sumo/opamp.d
  sumologic:
    collector_credentials_directory: /var/lib/otelcol-sumo/credentials
    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
    time_zone: Asia/Kolkata
    api_base_url: https://stag-open-events.sumologic.net/
    collector_fields:
      host.group: default
      deployment.environment: default
receivers:
  nop: {}
service:
  extensions:
    - sumologic
    - health_check
    - file_storage
    - opamp
  pipelines:
    logs/default:
      exporters:
        - nop
      receivers:
        - nop
    metrics/default:
      exporters:
        - nop
      receivers:
        - nop
    traces/default:
      exporters:
        - nop
      receivers:
        - nop
[ec2-user@ip-172-31-41-12 ~]$ 

________________


**Local New machine**

   ,     #_
   ~\_  ####_        Amazon Linux 2023
  ~~  \_#####\
  ~~     \###|
  ~~       \#/ ___   https://aws.amazon.com/linux/amazon-linux-2023
   ~~       V~' '->
    ~~~         /
      ~~._.   _/
         _/ _/
       _/m/'
[ec2-user@ip-172-31-40-232 ~]$ nano install.sh
[ec2-user@ip-172-31-40-232 ~]$ cat ./install.sh | SUMOLOGIC_INSTALLATION_TOKEN="U1VNT0w1aWs2bzJoVHI0ZXdkNjVoQ3FKVDhVc1FWTnBodHRwczovL3N0YWctZXZlbnRzLnN1bW9sb2dpYy5uZXQ=" sudo -E bash -s -- --tag "host.group=default" --tag "deployment.environment=default" --api https://stag-open-events.sumologic.net/ --timezone Asia/Kolkata -v 0.130.1-2196 
DOWNLOAD_URI = https://download-otel.sumologic.com
Detected OS type:       linux
Detected architecture:  amd64
Version specified: 0.130.1-2196
Detected operating system as amzn/2023.
Checking for curl...
Detected curl...
Downloading repository file: https://packages.sumologic.com/install/repositories/sumologic/stable/config_file.repo?os=amzn&dist=2023&source=script
done.
Installing yum-utils...
Amazon Linux 2023 Kernel Livepatch repository                                        235 kB/s |  23 kB     00:00    
sumologic_stable-source                                                              390  B/s | 833  B     00:02    
sumologic_stable-source                                                              5.3 kB/s | 3.9 kB     00:00    
Importing GPG key 0xD5A2FA16:
 Userid     : "https://packagecloud.io/sumologic/stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: F856 B440 4A86 50E3 58A4 8545 ED0D EF9C D5A2 FA16
 From       : https://packages.sumologic.com/sumologic/stable/gpgkey
sumologic_stable-source                                                               81  B/s | 296  B     00:03    
Package dnf-utils-4.3.0-13.amzn2023.0.5.noarch is already installed.
Dependencies resolved.
Nothing to do.
Complete!

WARNING: 
The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features.

Generating yum cache for sumologic_stable...
Importing GPG key 0xD5A2FA16:
 Userid     : "https://packagecloud.io/sumologic/stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: F856 B440 4A86 50E3 58A4 8545 ED0D EF9C D5A2 FA16
 From       : https://packages.sumologic.com/sumologic/stable/gpgkey
Generating yum cache for sumologic_stable-source...

The repository is setup! You can now install packages.
Installing otelcol-sumo-0.130.1-2196

Installed:
  otelcol-sumo-0.130.1-2196.x86_64                                                                                   

/usr/local/bin/otelcol-sumo
/usr/local/bin/otelcol-config
Running otelcol-sumo --version to verify installation
Installation succeded:  otelcol-sumo version 0.130.1-sumo-0-9cd0cff3fd63f4db526097a355ef9672f0956027
We are going to get and set up a default configuration for you
Generating configuration and saving it in /etc/otelcol-sumo
Reloading systemd
Enable otelcol-sumo service
Created symlink /etc/systemd/system/multi-user.target.wants/otelcol-sumo.service → /usr/lib/systemd/system/otelcol-sumo.service.
Starting otelcol-sumo service
[ec2-user@ip-172-31-40-232 ~]$ pwd
/home/ec2-user
[ec2-user@ip-172-31-40-232 ~]$ sudo su -
[root@ip-172-31-40-232 ~]# cd  sudo cat /etc/otelcol-sumo/
-bash: cd: too many arguments
[root@ip-172-31-40-232 ~]# cd cat /etc/otelcol-sumo/
-bash: cd: too many arguments
[root@ip-172-31-40-232 ~]# cd /etc/otelcol-sumo/
[root@ip-172-31-40-232 otelcol-sumo]# ls
conf.d  conf.d-available  env  opamp.d  sumologic.yaml
[root@ip-172-31-40-232 otelcol-sumo]# cd conf.d
[root@ip-172-31-40-232 conf.d]# ls
00-otelcol-config-settings.yaml
[root@ip-172-31-40-232 conf.d]# cat 00-otelcol-config-settings.yaml
extensions:
  sumologic:
    api_base_url: https://stag-open-events.sumologic.net/
    collector_fields:
      host.group: default
      deployment.environment: default
    time_zone: Asia/Kolkata
[root@ip-172-31-40-232 conf.d]# pwd
/etc/otelcol-sumo/conf.d
[root@ip-172-31-40-232 conf.d]# cd /home/ec2-user
[root@ip-172-31-40-232 ec2-user]# ls
install.sh


**Local Re Register**
[root@ip-172-31-40-232 ec2-user]# curl -sL https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector-packaging/refs/heads/main/install-script/install.sh | sudo -E bash -s -- -u -y -p
DOWNLOAD_URI = https://download-otel.sumologic.com
Detected OS type:       linux
Detected architecture:  amd64

Removed:
  otelcol-sumo-0.130.1-2196.x86_64                                                                                   

Uninstallation completed
[root@ip-172-31-40-232 ec2-user]# sudo rm -rf /var/lib/otelcol-sumo/credentials
[root@ip-172-31-40-232 ec2-user]# cat ./install.sh | SUMOLOGIC_INSTALLATION_TOKEN="U1VNT0w1aWs2bzJoVHI0ZXdkNjVoQ3FKVDhVc1FWTnBodHRwczovL3N0YWctZXZlbnRzLnN1bW9sb2dpYy5uZXQ=" sudo -E bash -s -- --tag "host.group=default" --tag "deployment.environment=default" --api https://stag-open-events.sumologic.net/ --timezone Asia/Kolkata -v 0.130.1-2196 
DOWNLOAD_URI = https://download-otel.sumologic.com
Detected OS type:       linux
Detected architecture:  amd64
Version specified: 0.130.1-2196
Detected operating system as amzn/2023.
Checking for curl...
Detected curl...
Downloading repository file: https://packages.sumologic.com/install/repositories/sumologic/stable/config_file.repo?os=amzn&dist=2023&source=script
done.
Installing yum-utils...
sumologic_stable-source                                                              338  B/s | 833  B     00:02    
Package dnf-utils-4.3.0-13.amzn2023.0.5.noarch is already installed.
Dependencies resolved.
Nothing to do.
Complete!

WARNING: 
The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features.

Generating yum cache for sumologic_stable...
Generating yum cache for sumologic_stable-source...

The repository is setup! You can now install packages.
Installing otelcol-sumo-0.130.1-2196

Installed:
  otelcol-sumo-0.130.1-2196.x86_64                                                                                   

/usr/local/bin/otelcol-sumo
/usr/local/bin/otelcol-config
Running otelcol-sumo --version to verify installation
Installation succeded:  otelcol-sumo version 0.130.1-sumo-0-9cd0cff3fd63f4db526097a355ef9672f0956027
We are going to get and set up a default configuration for you
Generating configuration and saving it in /etc/otelcol-sumo
Reloading systemd
Enable otelcol-sumo service
Starting otelcol-sumo service
[root@ip-172-31-40-232 ec2-user]# cd /etc/otelcol-sumo/conf.d
[root@ip-172-31-40-232 conf.d]# ls
00-otelcol-config-settings.yaml
[root@ip-172-31-40-232 conf.d]# cat 00-otelcol-config-settings.yaml
extensions:
  sumologic:
    api_base_url: https://stag-open-events.sumologic.net/
    collector_fields:
      host.group: default
      deployment.environment: default
    time_zone: Asia/Kolkata
[root@ip-172-31-40-232 conf.d]# 
