### PR TITLE
Use new DigiCert code signing action

### DIFF
--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -37,15 +37,13 @@ on:
         required: false
       productbuild_identity_name:
         required: false
-      microsoft_certificate:
+      sm_api_key:
         required: false
-      microsoft_certificate_password:
+      sm_client_cert_file_b64:
         required: false
-      microsoft_certhash:
+      sm_client_cert_password:
         required: false
-      microsoft_certname:
-        required: false
-      microsoft_description:
+      sm_keypair_alias:
         required: false
       gh_ci_token:
         required: true
@@ -357,15 +355,24 @@ jobs:
           echo "package_filename=$(basename "$package_path")"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Setup DigiCert certificate file
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          echo "${{ secrets.sm_client_cert_file_b64 }}" | base64 --decode > "${RUNNER_TEMP}/Certificate_pkcs12.p12"
+          echo "SM_CLIENT_CERT_FILE=${RUNNER_TEMP}/Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+
       - name: Sign MSI
         if: github.actor != 'dependabot[bot]'
-        uses: skymatic/code-sign-action@v3
+        uses: digicert/code-signing-software-trust-action@v1.2.1
         with:
-          certificate: ${{ secrets.microsoft_certificate }}
-          password: ${{ secrets.microsoft_certificate_password }}
-          certificatesha1: ${{ secrets.microsoft_certhash }}
-          description: ${{ secrets.microsoft_description }}
-          folder: ./msi/wix/bin/${{ inputs.package_arch }}/en-US
+          simple-signing-mode: true
+          input: ./msi/wix/bin/${{ inputs.package_arch }}/en-US
+          keypair-alias: ${{ secrets.sm_keypair_alias }}
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.sm_api_key }}
+          SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.sm_client_cert_password }}
 
       - name: Store MSI as action artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/_reusable_build_package.yml
+++ b/.github/workflows/_reusable_build_package.yml
@@ -355,14 +355,23 @@ jobs:
           echo "package_filename=$(basename "$package_path")"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Determine if MSI should be signed
+        id: signing-check
+        env:
+          SM_API_KEY: "${{ secrets.sm_api_key }}"
+        run: |
+          if [[ -n "${SM_API_KEY}" && "${{ github.actor }}" != "dependabot[bot]" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup DigiCert certificate file
-        if: github.actor != 'dependabot[bot]'
+        if: steps.signing-check.outputs.enabled == 'true'
         run: |
           echo "${{ secrets.sm_client_cert_file_b64 }}" | base64 --decode > "${RUNNER_TEMP}/Certificate_pkcs12.p12"
           echo "SM_CLIENT_CERT_FILE=${RUNNER_TEMP}/Certificate_pkcs12.p12" >> "$GITHUB_ENV"
 
       - name: Sign MSI
-        if: github.actor != 'dependabot[bot]'
+        if: steps.signing-check.outputs.enabled == 'true'
         uses: digicert/code-signing-software-trust-action@v1.2.1
         with:
           simple-signing-mode: true

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -82,11 +82,10 @@ jobs:
       apple_developer_certificate_password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD_NOV_25 }}
       productbuild_identity_name: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_IDENTITY }}
       gh_artifacts_token: ${{ secrets.GH_ARTIFACTS_TOKEN }}
-      microsoft_certificate: ${{ secrets.MICROSOFT_CERTIFICATE }}
-      microsoft_certificate_password: ${{ secrets.MICROSOFT_CERTIFICATE_PASSWORD }}
-      microsoft_certhash: ${{ secrets.MICROSOFT_CERTHASH }}
-      microsoft_certname: ${{ secrets.MICROSOFT_CERTNAME }}
-      microsoft_description: ${{ secrets.MICROSOFT_DESCRIPTION }}
+      sm_api_key: ${{ secrets.SM_API_KEY }}
+      sm_client_cert_file_b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+      sm_client_cert_password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+      sm_keypair_alias: ${{ secrets.SM_KEYPAIR_ALIAS }}
       gh_ci_token: ${{ secrets.GH_CI_TOKEN }}
       packagecloud_token: ${{ secrets.PACKAGECLOUD_TOKEN }}
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Updates CI to use DigiCert KeyLocker to sign Windows packages as there are now hardware token requirements for code signing on Windows.