### PR TITLE
feat: Add skip service start control flag

### DIFF
--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -101,15 +101,13 @@
         <ServiceControl Id="ServiceControlLifecycle"
           Name="!(loc.ServiceName)"
           Stop="both"
+          Start="install"
           Remove="uninstall"
           Wait="no" />
       </Component>
-      <Component Directory="BinFolder">
-        <Condition><![CDATA[START_SERVICE <> "false"]]></Condition>
-        <!-- Start only when START_SERVICE is not explicitly false -->
-        <ServiceControl Id="ServiceControlStart" Name="!(loc.ServiceName)" Start="install" Wait="no">
-        </ServiceControl>
-      </Component>
     </ComponentGroup>
+    <InstallExecuteSequence>
+      <StartServices Condition='START_SERVICE &lt;&gt; "false"' />
+    </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -3,7 +3,7 @@
   <?include variables.wxi ?>
 
   <Fragment>
-    <Property Id="START_SERVICE" Value="false" Secure="yes" />
+    <Property Id="START_SERVICE" Value="true" Secure="yes" />
     <ComponentGroup Id="HostMetricsComponents" Directory="APPDATAFOLDER">
       <Component Directory="ConfigFragmentsFolder">
         <File Id="HostMetricsConfig" Name="hostmetrics.yaml" Source="!(bindpath.assets)\conf.d\windows.yaml" />

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -109,7 +109,7 @@
           Name="!(loc.ServiceName)"
           Start="install"
           Wait="no">
-          <![CDATA[START_SERVICE <> "0"]]>
+          <![CDATA[START_SERVICE <> "false"]]>
         </ServiceControl>
       </Component>
     </ComponentGroup>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -3,7 +3,7 @@
   <?include variables.wxi ?>
 
   <Fragment>
-    <Property Id="START_SERVICE" Value="false" Secure="yes" />
+    <Property Id="START_SERVICE" Value="true" Secure="yes" />
     <ComponentGroup Id="HostMetricsComponents" Directory="APPDATAFOLDER">
       <Component Directory="ConfigFragmentsFolder">
         <File Id="HostMetricsConfig" Name="hostmetrics.yaml" Source="!(bindpath.assets)\conf.d\windows.yaml" />
@@ -105,11 +105,8 @@
           Wait="no" />
 
         <!-- Start only when START_SERVICE is not explicitly false -->
-        <ServiceControl Id="ServiceControlStart"
-          Name="!(loc.ServiceName)"
-          Start="install"
-          Wait="no">
-          <![CDATA[START_SERVICE <> "false"]]>
+        <ServiceControl Id="ServiceControlStart" Name="!(loc.ServiceName)" Start="install" Wait="no">
+          <Condition><![CDATA[START_SERVICE <> "false"]]></Condition>
         </ServiceControl>
       </Component>
     </ComponentGroup>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -104,7 +104,7 @@
           Remove="uninstall"
           Wait="no" />
 
-        <!-- Start only when START_SERVICE is not explicitly 0 -->
+        <!-- Start only when START_SERVICE is not explicitly false -->
         <ServiceControl Id="ServiceControlStart"
           Name="!(loc.ServiceName)"
           Start="install"

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -107,7 +107,7 @@
       </Component>
     </ComponentGroup>
     <InstallExecuteSequence>
-      <StartServices Condition='START_SERVICE &lt;&gt; "false"' />
+      <StartServices Condition='START_SERVICE &lt;&gt; "false" AND NOT Installed' />
     </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -3,7 +3,7 @@
   <?include variables.wxi ?>
 
   <Fragment>
-    <Property Id="START_SERVICE" Value="true" Secure="yes" />
+    <Property Id="START_SERVICE" Value="false" Secure="yes" />
     <ComponentGroup Id="HostMetricsComponents" Directory="APPDATAFOLDER">
       <Component Directory="ConfigFragmentsFolder">
         <File Id="HostMetricsConfig" Name="hostmetrics.yaml" Source="!(bindpath.assets)\conf.d\windows.yaml" />

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -103,10 +103,11 @@
           Stop="both"
           Remove="uninstall"
           Wait="no" />
-
+      </Component>
+      <Component Directory="BinFolder">
+        <Condition><![CDATA[START_SERVICE <> "false"]]></Condition>
         <!-- Start only when START_SERVICE is not explicitly false -->
         <ServiceControl Id="ServiceControlStart" Name="!(loc.ServiceName)" Start="install" Wait="no">
-          <Condition><![CDATA[START_SERVICE <> "false"]]></Condition>
         </ServiceControl>
       </Component>
     </ComponentGroup>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -3,6 +3,7 @@
   <?include variables.wxi ?>
 
   <Fragment>
+    <Property Id="START_SERVICE" Value="true" Secure="yes" />
     <ComponentGroup Id="HostMetricsComponents" Directory="APPDATAFOLDER">
       <Component Directory="ConfigFragmentsFolder">
         <File Id="HostMetricsConfig" Name="hostmetrics.yaml" Source="!(bindpath.assets)\conf.d\windows.yaml" />
@@ -96,8 +97,20 @@
             ThirdFailureActionType="restart" RestartServiceDelayInSeconds="0" ResetPeriodInDays="0" />
         </ServiceInstall>
 
-        <!-- Start/Stop/Remove OTC service -->
-        <ServiceControl Id="StartServiceControl" Name="!(loc.ServiceName)" Start="install" Stop="both" Remove="uninstall" Wait="no" />
+        <!-- Stop/remove always -->
+        <ServiceControl Id="ServiceControlLifecycle"
+          Name="!(loc.ServiceName)"
+          Stop="both"
+          Remove="uninstall"
+          Wait="no" />
+
+        <!-- Start only when START_SERVICE is not explicitly 0 -->
+        <ServiceControl Id="ServiceControlStart"
+          Name="!(loc.ServiceName)"
+          Start="install"
+          Wait="no">
+          <![CDATA[START_SERVICE <> "0"]]>
+        </ServiceControl>
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -107,7 +107,7 @@
       </Component>
     </ComponentGroup>
     <InstallExecuteSequence>
-      <StartServices Condition='START_SERVICE &lt;&gt; "false" AND NOT Installed' />
+      <StartServices Condition='(NOT Installed AND START_SERVICE &lt;&gt; "false") OR WIX_UPGRADE_DETECTED' />
     </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -107,7 +107,7 @@
       </Component>
     </ComponentGroup>
     <InstallExecuteSequence>
-      <StartServices Condition='(NOT Installed AND START_SERVICE &lt;&gt; "false") OR Installed' />
+      <StartServices Condition='Installed OR WIX_UPGRADE_DETECTED OR (NOT Installed AND START_SERVICE &lt;&gt; "false")' />
     </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -107,7 +107,7 @@
       </Component>
     </ComponentGroup>
     <InstallExecuteSequence>
-      <StartServices Condition='(NOT Installed AND START_SERVICE &lt;&gt; "false") OR WIX_UPGRADE_DETECTED' />
+      <StartServices Condition='(NOT Installed AND START_SERVICE &lt;&gt; "false") OR Installed' />
     </InstallExecuteSequence>
   </Fragment>
 </Wix>


### PR DESCRIPTION
To support skipRegistration flag in windows, we need to new flag START_SERVICE(default true) in msi to control service start behaviour on collector install event.

winget could preserve this flag, so only fresh installation should use this flag, upgrades should start service irrespective of this flag. handled the same.

To decide whether to start windows service on installation/upgrade, we use below condition.
1. Start service on all upgrade/repair msi cases. 
2. Start service on installation when START_SERVICE is not set / true.
3. Don't start service on installation when START_SERVICE is set to false.

`<StartServices Condition='(NOT Installed AND START_SERVICE &lt;&gt; "false") OR Installed' />`

**Local testing:**
 msiexec.exe /i "C:\otelcol-sumo_0.153.0.3018_en-US.x64.msi" /passive REBOOT=ReallySuppress INSTALLATIONTOKEN=**** TAGS=deployment.environment=default,host.group=default API=https://long-open-events.sumologic.net/ OPAMPAPI=wss://long-opamp-events.sumologic.net/v1/opamp ADDLOCAL=REMOTELYMANAGED START_SERVICE=false /L*V "C:\install_log.txt
 
 1. fresh install without START_SERVICE flag (default behaviour) - Service started
 2. fresh install with START_SERVICE flag as false - Service installed and not started.
 3. fresh install with START_SERVICE flag as true - Service started
 4. Upgrade normally without START_SERVICE flag used - Service started after upgrade.
 5. Upgrade with START_SERVICE = false - Service started after upgrade.
