### PR TITLE
fix: migrate FIPS test runner from self-hosted EC2 to github-hosted windows-2022

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -264,7 +264,7 @@ jobs:
             runs_on: windows-2022
             test_filter: "TestInstallScript/(no_arguments|installation_token_only|installation_token_and_ephemeral|installation_token_and_fips_on_non_fips_system|installation_token_and_hostmetrics|installation_token_and_remotely-managed)"
           - arch_os: windows_amd64_fips
-            runs_on: [self-hosted, windows, fips]
+            runs_on: windows-2022
             test_filter: "TestInstallScript/installation_token_and_fips$$"
             fips_runner: true
           - arch_os: windows_amd64_2
@@ -332,6 +332,18 @@ jobs:
           path: artifacts/
           pattern: otelcol-sumo_*x64-fips.msi
           merge-multiple: true
+
+      - name: Enable FIPS mode via registry
+        if: ${{ runner.os == 'Windows' && matrix.fips_runner == true }}
+        shell: powershell
+        run: |
+          Set-ItemProperty `
+            -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy" `
+            -Name "Enabled" -Value 1 -Type DWord
+          Write-Host "FIPS registry key set - verifying..."
+          $val = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy" -Name Enabled).Enabled
+          if ($val -ne 1) { Write-Error "FIPS registry key not set correctly"; exit 1 }
+          Write-Host "FIPS mode enabled (registry value: $val)"
 
       - name: Show packages
         if: ${{ steps.changed-files.outputs.any_changed == 'true' && runner.os != 'Windows' }}

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -337,9 +337,9 @@ jobs:
         if: ${{ runner.os == 'Windows' && matrix.fips_runner == true }}
         shell: powershell
         run: |
-          Set-ItemProperty `
+          New-ItemProperty `
             -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy" `
-            -Name "Enabled" -Value 1 -Type DWord
+            -Name "Enabled" -Value 1 -PropertyType DWord -Force | Out-Null
           Write-Host "FIPS registry key set - verifying..."
           $val = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy" -Name Enabled).Enabled
           if ($val -ne 1) { Write-Error "FIPS registry key not set correctly"; exit 1 }


### PR DESCRIPTION
Changing it to a GitHub-hosted runner because a self-hosted runner requires an EC2 instance. Additionally, there could be storage issues on the EC2 instance if cleanup is not handled properly. Since this is only for testing, there is no need to keep an instance running continuously.