### PR TITLE
feat: Add auto-start capability to linux deamon

### DIFF
--- a/assets/services/systemd/otelcol-sumo.service
+++ b/assets/services/systemd/otelcol-sumo.service
@@ -9,6 +9,8 @@ MemoryHigh=2000M
 MemoryMax=3000M
 TimeoutStopSec=20
 EnvironmentFile=-/etc/otelcol-sumo/env/*.env
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/otelcol-sumo.service
+++ b/examples/systemd/otelcol-sumo.service
@@ -9,6 +9,8 @@ MemoryHigh=2000M
 MemoryMax=3000M
 TimeoutStopSec=20
 EnvironmentFile=-/etc/otelcol-sumo/env/*.env
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Adds auto-restart capability to systemd daemon for otel service.
Context: If otel process stops/crashes, we need systemd to auto-start it, but right now, it stays stopped. It's good to have the otel process to be started automatically to improve reliability.

Same flow if we look at mac launchd, it has auto-start. 
https://github.com/SumoLogic/sumologic-otel-collector-packaging/blob/jagan2221-patch-2/assets/services/launchd/com.sumologic.otelcol-sumo.plist#L25

local testing:
1., killed otelcol-sumo process using pkill -> Service remained in stopped state.
2. Added the auto-restart patch to /lib/systemd/system/otelcol-sumo.service
3. Reloaded systemd deamon for changes to take effect.
4. killed otelcol-sumo process again -> Now otel process was auto-restarted by systemd.
sudo systemctl status otelcol-sumo 
```
otelcol-sumo.service - Sumo Logic Distribution for OpenTelemetry Collector
     Loaded: loaded (/lib/systemd/system/otelcol-sumo.service; enabled; vendor preset: enabled)
     Active: **activating (auto-restart) (Result: signal)** since Tue 2026-06-16 09:37:48 UTC; 2s ago
    Process: 16668 ExecStart=/usr/share/otelcol-sumo/otelcol-sumo.sh (code=killed, signal=KILL)
   Main PID: 16668 (code=killed, signal=KILL)
```

Note: sudo systemctl stop otelcol-sumo , stopping the service properly via systemd won't get auto-restart. This is intended behaviour we need.
