### PR TITLE
feat: configure Windows service as Automatic (Delayed Start)

### DIFF
--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -94,7 +94,8 @@
           Description="!(loc.ServiceDescription)" Type="ownProcess" Vital="yes" Start="auto" Account="LocalSystem"
           ErrorControl="normal" Arguments="[SERVICEARGUMENTS]" Interactive="no" LoadOrderGroup="NetworkProvider">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart"
-            ThirdFailureActionType="restart" RestartServiceDelayInSeconds="0" ResetPeriodInDays="0" />
+            ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" ResetPeriodInDays="0"
+            DelayedAutoStart="yes" />
         </ServiceInstall>
 
         <!-- Stop/remove always -->
@@ -107,7 +108,7 @@
       </Component>
     </ComponentGroup>
     <InstallExecuteSequence>
-      <StartServices Condition='Installed OR WIX_UPGRADE_DETECTED OR (NOT Installed AND START_SERVICE &lt;&gt; "false")' />
+      <StartServices Condition='Installed OR WIX_UPGRADE_DETECTED OR (NOT Installed AND START_SERVICE &lt;&gt; "false")' />
     </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/msi/wix/components.wxs
+++ b/msi/wix/components.wxs
@@ -94,9 +94,12 @@
           Description="!(loc.ServiceDescription)" Type="ownProcess" Vital="yes" Start="auto" Account="LocalSystem"
           ErrorControl="normal" Arguments="[SERVICEARGUMENTS]" Interactive="no" LoadOrderGroup="NetworkProvider">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart"
-            ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" ResetPeriodInDays="0"
-            DelayedAutoStart="yes" />
+            ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" ResetPeriodInDays="0" />
         </ServiceInstall>
+
+        <!-- Configure Automatic (Delayed Start) via registry -->
+        <RegistryValue Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\!(loc.ServiceName)"
+          Name="DelayedAutostart" Type="integer" Value="1" />
 
         <!-- Stop/remove always -->
         <ServiceControl Id="ServiceControlLifecycle"


### PR DESCRIPTION
## Summary
- Configures the `otelcol-sumo` Windows service with `DelayedAutoStart="yes"` so it starts after critical system and networking services are initialized
- Adds a 5-second `RestartServiceDelayInSeconds` to prevent system overload on repeated service failures
- Fixes startup issues on Windows machines where the service starts before network initialization is complete

Resolves: [SUMO-284073](https://sumologic.atlassian.net/browse/SUMO-284073)

## Test plan
- [ ] Verify MSI builds successfully with the updated `components.wxs`
- [ ] Install MSI on Windows and confirm service is registered as "Automatic (Delayed Start)"
- [ ] Verify service restart behavior respects the 5-second delay after failure
- [ ] Confirm service still starts normally after system boot


<img width="1237" height="867" alt="Screenshot 2026-07-20 at 1 52 35 PM" src="https://github.com/user-attachments/assets/a34ca225-2e95-41b7-8e66-c0208e2ea490" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)